### PR TITLE
diffchecker: comparar dos textos y mezclarlos

### DIFF
--- a/assets/css/brutal/tool.css
+++ b/assets/css/brutal/tool.css
@@ -1,8 +1,10 @@
 /* ============================================================
    TOOL LAYER
-   Shared chrome for the standalone browser apps (md2html, pdf2md).
-   Both were generated from the same template, so they use the same
-   class names and can share one stylesheet.
+   Shared chrome for the standalone browser apps (md2html, pdf2md
+   and diffchecker). The first two were generated from the same
+   template, so they use the same class names and can share one
+   stylesheet; diffchecker reuses that chrome and adds its own
+   section at the end of this file.
 
    Selectors are kept exactly as the apps' JavaScript expects them:
    `light` on <body>, `dragover` on the drop zone, `active` on chips
@@ -784,5 +786,470 @@ code {
   }
   .theme-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+/* ============================================================
+   DIFFCHECKER
+   Everything below belongs to /diffchecker/ only. It reuses the
+   chrome above (header, hero, buttons, drop zone, footer) and adds
+   the two things that tool needs and the others do not: a pair of
+   editors and the diff grid with its merge controls.
+
+   The grid is one row template repeated, not two scrolling panes.
+   That is what keeps both sides aligned line by line without a
+   scroll sync, which is where these tools usually break.
+   ============================================================ */
+
+:root {
+  /* Added and removed keep the site's own accents: lime for what comes
+     in, the danger red for what goes out. No GitHub green anywhere. */
+  --diff-add-bg: rgba(79, 179, 31, 0.16);
+  --diff-add-ink: #2f7a0f;
+  --diff-add-mark: rgba(79, 179, 31, 0.42);
+  --diff-del-bg: rgba(255, 93, 108, 0.15);
+  --diff-del-ink: #c22436;
+  --diff-del-mark: rgba(255, 93, 108, 0.42);
+  --diff-rule: rgba(0, 0, 0, 0.14);
+  /* Solo el valor de partida: el script mide la cabecera de verdad y lo
+     reescribe, porque su altura depende de la tipografia y del ancho. */
+  --header-h: 62px;
+}
+
+body:not(.light) {
+  --diff-add-bg: rgba(184, 255, 60, 0.14);
+  --diff-add-ink: #b8ff3c;
+  --diff-add-mark: rgba(184, 255, 60, 0.34);
+  --diff-del-bg: rgba(255, 93, 108, 0.18);
+  --diff-del-ink: #ff8d97;
+  --diff-del-mark: rgba(255, 93, 108, 0.42);
+  --diff-rule: rgba(244, 247, 245, 0.16);
+}
+
+/* ---------- Shell ---------- */
+
+.diff-app {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 clamp(12px, 4vw, 40px);
+}
+
+/* ---------- Toolbar ---------- */
+
+.diff-bar {
+  position: sticky;
+  top: var(--header-h);
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  background: var(--surface);
+  border: var(--line) solid var(--ink);
+  box-shadow: var(--shadow) var(--shadow) 0 var(--shadow-col);
+  margin-bottom: var(--gap-sm);
+}
+
+.diff-bar .spacer {
+  flex: 1 1 auto;
+}
+
+/* Forces the rest of the toolbar onto a second line: the view switch and the
+   merge controls on top, the options and the housekeeping below. */
+.bar-break {
+  flex-basis: 100%;
+  height: 0;
+}
+
+.diff-bar .switch {
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+.diff-bar .switch input {
+  width: 15px;
+  height: 15px;
+}
+
+/* Segmented view switch. One frame, dividers between the options. */
+.segmented {
+  display: flex;
+  border: var(--line) solid var(--ink);
+}
+
+.seg-btn {
+  background: transparent;
+  border: none;
+  border-left: var(--line) solid var(--ink);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  cursor: pointer;
+  transition:
+    background var(--base) ease,
+    color var(--base) ease;
+}
+.seg-btn:first-child {
+  border-left: none;
+}
+.seg-btn:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+.seg-btn[aria-pressed="true"] {
+  background: var(--ink);
+  color: var(--bg);
+}
+.seg-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ---------- Change counter ---------- */
+
+.dstat {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dstat b {
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+.dstat .is-add {
+  color: var(--diff-add-ink);
+}
+.dstat .is-del {
+  color: var(--diff-del-ink);
+}
+.dstat .is-same {
+  color: var(--muted);
+}
+
+/* ---------- Editors ---------- */
+
+.editor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--gap-sm);
+}
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--surface);
+  border: var(--line) solid var(--ink);
+  box-shadow: var(--shadow) var(--shadow) 0 var(--shadow-col);
+}
+
+.editor-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: var(--line) solid var(--ink);
+  background: var(--surface-2);
+}
+
+.editor-head h2 {
+  font-family: var(--font-display);
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.editor-head .fname {
+  color: var(--muted);
+  font-size: 0.74rem;
+  margin-left: auto;
+}
+
+.editor textarea {
+  flex: 1;
+  min-height: 320px;
+  resize: vertical;
+  border: none;
+  border-bottom: var(--line) solid var(--ink);
+  background: var(--surface);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.55;
+  padding: 14px;
+  tab-size: 4;
+}
+.editor textarea:focus {
+  outline: none;
+  background: var(--surface-2);
+}
+.editor textarea::placeholder {
+  color: var(--muted);
+}
+
+/* Inside an editor the drop zone is a strip under the text, so it drops the
+   dashed frame and keeps only the rule that separates it. */
+.editor .dropzone {
+  border: none;
+  padding: 12px 14px;
+}
+.editor .dropzone .dz-or {
+  margin: 0 0 4px;
+}
+
+/* ---------- Diff grid ---------- */
+
+.diff-grid {
+  border: var(--line) solid var(--ink);
+  box-shadow: var(--shadow) var(--shadow) 0 var(--shadow-col);
+  background: var(--surface);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.drow {
+  display: grid;
+  grid-template-columns:
+    3.2rem 1.1rem minmax(0, 1fr)
+    7.2rem
+    3.2rem 1.1rem minmax(0, 1fr);
+  border-bottom: var(--line-hair) solid var(--diff-rule);
+}
+.drow:last-child {
+  border-bottom: none;
+}
+
+/* Unified keeps both line numbers and moves the merge controls to the end,
+   since there is no middle any more. */
+.diff-grid.unified .drow {
+  grid-template-columns: 3.2rem 3.2rem 1.1rem minmax(0, 1fr) 7.2rem;
+}
+
+.dnum {
+  padding: 2px 8px 2px 0;
+  text-align: right;
+  color: var(--muted);
+  font-size: 0.74rem;
+  user-select: none;
+  border-right: var(--line-hair) solid var(--diff-rule);
+}
+
+.dsign {
+  text-align: center;
+  user-select: none;
+  font-weight: 700;
+}
+
+.dtext {
+  padding: 2px 10px;
+  /* Long lines wrap instead of scrolling: there is no horizontal scroll
+     anywhere in this view, so the two sides can never drift apart. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.dtext:empty::after {
+  content: "";
+}
+
+/* Tinting goes on the cells, not the row: in a change block the left
+   side is what leaves and the right side is what arrives. */
+.drow.change .side-l:not(.dpad),
+.drow.remove .side-l:not(.dpad) {
+  background: var(--diff-del-bg);
+}
+.drow.change .side-r:not(.dpad),
+.drow.add .side-r:not(.dpad) {
+  background: var(--diff-add-bg);
+}
+.drow.remove .side-l.dsign,
+.drow.change .side-l.dsign {
+  color: var(--diff-del-ink);
+}
+.drow.add .side-r.dsign,
+.drow.change .side-r.dsign {
+  color: var(--diff-add-ink);
+}
+
+/* Padding cell: that side has no line at all here, so it must read as
+   absent and never pick up the tint of the block it sits in. */
+.drow .dpad {
+  background: var(--surface-2);
+}
+
+mark.wdel,
+mark.wadd {
+  color: inherit;
+  padding: 0 1px;
+}
+mark.wdel {
+  background: var(--diff-del-mark);
+}
+mark.wadd {
+  background: var(--diff-add-mark);
+}
+
+/* Equal for the comparison, different in the file: only happens with the
+   ignore options on. Flagged so the download is never a surprise. */
+.drow.soft .dtext {
+  border-bottom: var(--line-hair) dotted var(--muted);
+}
+
+/* The block the keyboard navigation is standing on. */
+.drow.current .dnum {
+  background: var(--ink);
+  color: var(--bg);
+}
+
+/* ---------- Merge controls ---------- */
+
+.dmerge {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 2px;
+  padding: 2px;
+  border-left: var(--line-hair) solid var(--diff-rule);
+  border-right: var(--line-hair) solid var(--diff-rule);
+}
+
+.hunk-btn {
+  background: var(--surface-2);
+  border: var(--line-hair) solid var(--ink);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.72rem;
+  line-height: 1.2;
+  padding: 3px 4px;
+  min-width: 1.6rem;
+  cursor: pointer;
+  transition:
+    background var(--fast) ease,
+    color var(--fast) ease;
+}
+/* Dos triangulos necesitan mas sitio que uno o quedan pegados. */
+.hunk-btn[data-choice="both"] {
+  min-width: 2.3rem;
+}
+.hunk-btn:hover {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+.hunk-btn[aria-pressed="true"] {
+  background: var(--ink);
+  color: var(--bg);
+}
+
+/* The side that lost the choice stays readable but clearly out. */
+.drow[data-choice="right"] .side-l,
+.drow[data-choice="left"] .side-r {
+  opacity: 0.34;
+}
+
+/* ---------- Folded runs ---------- */
+
+.dfold {
+  display: block;
+  width: 100%;
+  background: var(--surface-2);
+  border: none;
+  border-bottom: var(--line-hair) solid var(--diff-rule);
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  text-align: center;
+  cursor: pointer;
+}
+.dfold:hover {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+/* ---------- Result ---------- */
+
+.result-pane {
+  border: var(--line) solid var(--ink);
+  box-shadow: var(--shadow) var(--shadow) 0 var(--shadow-col);
+  background: var(--surface);
+}
+
+.result-pane pre {
+  margin: 0;
+  padding: 16px;
+  max-height: 70vh;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* ---------- Empty state ---------- */
+
+.diff-empty {
+  border: var(--line) dashed var(--ink);
+  padding: clamp(40px, 8vw, 80px) 20px;
+  text-align: center;
+  color: var(--muted);
+}
+
+.diff-empty strong {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin-bottom: 8px;
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 900px) {
+  .editor-grid {
+    grid-template-columns: 1fr;
+  }
+  /* Wrapped onto several lines, the toolbar would eat most of a phone
+     screen if it stayed stuck to the top. */
+  .diff-bar {
+    position: static;
+  }
+  .diff-grid {
+    font-size: 0.78rem;
+  }
+  /* Side by side needs width it does not have here. The script forces the
+     unified view below this breakpoint and disables the switch; these are
+     its columns, tightened. */
+  .diff-grid.unified .drow {
+    grid-template-columns: 2.6rem 2.6rem 0.9rem minmax(0, 1fr) 6.4rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .diff-bar {
+    gap: 8px;
+  }
+  .seg-btn {
+    padding: 7px 10px;
+    font-size: 0.7rem;
+  }
+  .diff-grid.unified .drow {
+    grid-template-columns: 2.4rem 2.4rem 0.9rem minmax(0, 1fr) 5.6rem;
   }
 }

--- a/assets/css/tool.css
+++ b/assets/css/tool.css
@@ -238,9 +238,11 @@ a {
 
 /* ============================================================
    TOOL LAYER
-   Shared chrome for the standalone browser apps (md2html, pdf2md).
-   Both were generated from the same template, so they use the same
-   class names and can share one stylesheet.
+   Shared chrome for the standalone browser apps (md2html, pdf2md
+   and diffchecker). The first two were generated from the same
+   template, so they use the same class names and can share one
+   stylesheet; diffchecker reuses that chrome and adds its own
+   section at the end of this file.
 
    Selectors are kept exactly as the apps' JavaScript expects them:
    `light` on <body>, `dragover` on the drop zone, `active` on chips
@@ -1022,5 +1024,470 @@ code {
   }
   .theme-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+/* ============================================================
+   DIFFCHECKER
+   Everything below belongs to /diffchecker/ only. It reuses the
+   chrome above (header, hero, buttons, drop zone, footer) and adds
+   the two things that tool needs and the others do not: a pair of
+   editors and the diff grid with its merge controls.
+
+   The grid is one row template repeated, not two scrolling panes.
+   That is what keeps both sides aligned line by line without a
+   scroll sync, which is where these tools usually break.
+   ============================================================ */
+
+:root {
+  /* Added and removed keep the site's own accents: lime for what comes
+     in, the danger red for what goes out. No GitHub green anywhere. */
+  --diff-add-bg: rgba(79, 179, 31, 0.16);
+  --diff-add-ink: #2f7a0f;
+  --diff-add-mark: rgba(79, 179, 31, 0.42);
+  --diff-del-bg: rgba(255, 93, 108, 0.15);
+  --diff-del-ink: #c22436;
+  --diff-del-mark: rgba(255, 93, 108, 0.42);
+  --diff-rule: rgba(0, 0, 0, 0.14);
+  /* Solo el valor de partida: el script mide la cabecera de verdad y lo
+     reescribe, porque su altura depende de la tipografia y del ancho. */
+  --header-h: 62px;
+}
+
+body:not(.light) {
+  --diff-add-bg: rgba(184, 255, 60, 0.14);
+  --diff-add-ink: #b8ff3c;
+  --diff-add-mark: rgba(184, 255, 60, 0.34);
+  --diff-del-bg: rgba(255, 93, 108, 0.18);
+  --diff-del-ink: #ff8d97;
+  --diff-del-mark: rgba(255, 93, 108, 0.42);
+  --diff-rule: rgba(244, 247, 245, 0.16);
+}
+
+/* ---------- Shell ---------- */
+
+.diff-app {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 clamp(12px, 4vw, 40px);
+}
+
+/* ---------- Toolbar ---------- */
+
+.diff-bar {
+  position: sticky;
+  top: var(--header-h);
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  background: var(--surface);
+  border: var(--line) solid var(--ink);
+  box-shadow: var(--shadow) var(--shadow) 0 var(--shadow-col);
+  margin-bottom: var(--gap-sm);
+}
+
+.diff-bar .spacer {
+  flex: 1 1 auto;
+}
+
+/* Forces the rest of the toolbar onto a second line: the view switch and the
+   merge controls on top, the options and the housekeeping below. */
+.bar-break {
+  flex-basis: 100%;
+  height: 0;
+}
+
+.diff-bar .switch {
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+.diff-bar .switch input {
+  width: 15px;
+  height: 15px;
+}
+
+/* Segmented view switch. One frame, dividers between the options. */
+.segmented {
+  display: flex;
+  border: var(--line) solid var(--ink);
+}
+
+.seg-btn {
+  background: transparent;
+  border: none;
+  border-left: var(--line) solid var(--ink);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  cursor: pointer;
+  transition:
+    background var(--base) ease,
+    color var(--base) ease;
+}
+.seg-btn:first-child {
+  border-left: none;
+}
+.seg-btn:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+.seg-btn[aria-pressed="true"] {
+  background: var(--ink);
+  color: var(--bg);
+}
+.seg-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ---------- Change counter ---------- */
+
+.dstat {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dstat b {
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+.dstat .is-add {
+  color: var(--diff-add-ink);
+}
+.dstat .is-del {
+  color: var(--diff-del-ink);
+}
+.dstat .is-same {
+  color: var(--muted);
+}
+
+/* ---------- Editors ---------- */
+
+.editor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--gap-sm);
+}
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--surface);
+  border: var(--line) solid var(--ink);
+  box-shadow: var(--shadow) var(--shadow) 0 var(--shadow-col);
+}
+
+.editor-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: var(--line) solid var(--ink);
+  background: var(--surface-2);
+}
+
+.editor-head h2 {
+  font-family: var(--font-display);
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.editor-head .fname {
+  color: var(--muted);
+  font-size: 0.74rem;
+  margin-left: auto;
+}
+
+.editor textarea {
+  flex: 1;
+  min-height: 320px;
+  resize: vertical;
+  border: none;
+  border-bottom: var(--line) solid var(--ink);
+  background: var(--surface);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.55;
+  padding: 14px;
+  tab-size: 4;
+}
+.editor textarea:focus {
+  outline: none;
+  background: var(--surface-2);
+}
+.editor textarea::placeholder {
+  color: var(--muted);
+}
+
+/* Inside an editor the drop zone is a strip under the text, so it drops the
+   dashed frame and keeps only the rule that separates it. */
+.editor .dropzone {
+  border: none;
+  padding: 12px 14px;
+}
+.editor .dropzone .dz-or {
+  margin: 0 0 4px;
+}
+
+/* ---------- Diff grid ---------- */
+
+.diff-grid {
+  border: var(--line) solid var(--ink);
+  box-shadow: var(--shadow) var(--shadow) 0 var(--shadow-col);
+  background: var(--surface);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.drow {
+  display: grid;
+  grid-template-columns:
+    3.2rem 1.1rem minmax(0, 1fr)
+    7.2rem
+    3.2rem 1.1rem minmax(0, 1fr);
+  border-bottom: var(--line-hair) solid var(--diff-rule);
+}
+.drow:last-child {
+  border-bottom: none;
+}
+
+/* Unified keeps both line numbers and moves the merge controls to the end,
+   since there is no middle any more. */
+.diff-grid.unified .drow {
+  grid-template-columns: 3.2rem 3.2rem 1.1rem minmax(0, 1fr) 7.2rem;
+}
+
+.dnum {
+  padding: 2px 8px 2px 0;
+  text-align: right;
+  color: var(--muted);
+  font-size: 0.74rem;
+  user-select: none;
+  border-right: var(--line-hair) solid var(--diff-rule);
+}
+
+.dsign {
+  text-align: center;
+  user-select: none;
+  font-weight: 700;
+}
+
+.dtext {
+  padding: 2px 10px;
+  /* Long lines wrap instead of scrolling: there is no horizontal scroll
+     anywhere in this view, so the two sides can never drift apart. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.dtext:empty::after {
+  content: "";
+}
+
+/* Tinting goes on the cells, not the row: in a change block the left
+   side is what leaves and the right side is what arrives. */
+.drow.change .side-l:not(.dpad),
+.drow.remove .side-l:not(.dpad) {
+  background: var(--diff-del-bg);
+}
+.drow.change .side-r:not(.dpad),
+.drow.add .side-r:not(.dpad) {
+  background: var(--diff-add-bg);
+}
+.drow.remove .side-l.dsign,
+.drow.change .side-l.dsign {
+  color: var(--diff-del-ink);
+}
+.drow.add .side-r.dsign,
+.drow.change .side-r.dsign {
+  color: var(--diff-add-ink);
+}
+
+/* Padding cell: that side has no line at all here, so it must read as
+   absent and never pick up the tint of the block it sits in. */
+.drow .dpad {
+  background: var(--surface-2);
+}
+
+mark.wdel,
+mark.wadd {
+  color: inherit;
+  padding: 0 1px;
+}
+mark.wdel {
+  background: var(--diff-del-mark);
+}
+mark.wadd {
+  background: var(--diff-add-mark);
+}
+
+/* Equal for the comparison, different in the file: only happens with the
+   ignore options on. Flagged so the download is never a surprise. */
+.drow.soft .dtext {
+  border-bottom: var(--line-hair) dotted var(--muted);
+}
+
+/* The block the keyboard navigation is standing on. */
+.drow.current .dnum {
+  background: var(--ink);
+  color: var(--bg);
+}
+
+/* ---------- Merge controls ---------- */
+
+.dmerge {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 2px;
+  padding: 2px;
+  border-left: var(--line-hair) solid var(--diff-rule);
+  border-right: var(--line-hair) solid var(--diff-rule);
+}
+
+.hunk-btn {
+  background: var(--surface-2);
+  border: var(--line-hair) solid var(--ink);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.72rem;
+  line-height: 1.2;
+  padding: 3px 4px;
+  min-width: 1.6rem;
+  cursor: pointer;
+  transition:
+    background var(--fast) ease,
+    color var(--fast) ease;
+}
+/* Dos triangulos necesitan mas sitio que uno o quedan pegados. */
+.hunk-btn[data-choice="both"] {
+  min-width: 2.3rem;
+}
+.hunk-btn:hover {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+.hunk-btn[aria-pressed="true"] {
+  background: var(--ink);
+  color: var(--bg);
+}
+
+/* The side that lost the choice stays readable but clearly out. */
+.drow[data-choice="right"] .side-l,
+.drow[data-choice="left"] .side-r {
+  opacity: 0.34;
+}
+
+/* ---------- Folded runs ---------- */
+
+.dfold {
+  display: block;
+  width: 100%;
+  background: var(--surface-2);
+  border: none;
+  border-bottom: var(--line-hair) solid var(--diff-rule);
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  text-align: center;
+  cursor: pointer;
+}
+.dfold:hover {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+/* ---------- Result ---------- */
+
+.result-pane {
+  border: var(--line) solid var(--ink);
+  box-shadow: var(--shadow) var(--shadow) 0 var(--shadow-col);
+  background: var(--surface);
+}
+
+.result-pane pre {
+  margin: 0;
+  padding: 16px;
+  max-height: 70vh;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* ---------- Empty state ---------- */
+
+.diff-empty {
+  border: var(--line) dashed var(--ink);
+  padding: clamp(40px, 8vw, 80px) 20px;
+  text-align: center;
+  color: var(--muted);
+}
+
+.diff-empty strong {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin-bottom: 8px;
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 900px) {
+  .editor-grid {
+    grid-template-columns: 1fr;
+  }
+  /* Wrapped onto several lines, the toolbar would eat most of a phone
+     screen if it stayed stuck to the top. */
+  .diff-bar {
+    position: static;
+  }
+  .diff-grid {
+    font-size: 0.78rem;
+  }
+  /* Side by side needs width it does not have here. The script forces the
+     unified view below this breakpoint and disables the switch; these are
+     its columns, tightened. */
+  .diff-grid.unified .drow {
+    grid-template-columns: 2.6rem 2.6rem 0.9rem minmax(0, 1fr) 6.4rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .diff-bar {
+    gap: 8px;
+  }
+  .seg-btn {
+    padding: 7px 10px;
+    font-size: 0.7rem;
+  }
+  .diff-grid.unified .drow {
+    grid-template-columns: 2.4rem 2.4rem 0.9rem minmax(0, 1fr) 5.6rem;
   }
 }

--- a/build/lib/sitemap.mjs
+++ b/build/lib/sitemap.mjs
@@ -17,6 +17,7 @@ const STATIC_URLS = [
   { path: "/historia/", changefreq: "monthly", priority: "0.5" },
   { path: "/md2html/", changefreq: "monthly", priority: "0.9" },
   { path: "/pdf2md/", changefreq: "monthly", priority: "0.9" },
+  { path: "/diffchecker/", changefreq: "monthly", priority: "0.9" },
 ];
 
 /**

--- a/build/scripts/check-diff-engine.mjs
+++ b/build/scripts/check-diff-engine.mjs
@@ -1,0 +1,417 @@
+/**
+ * Checks the diff engine that powers /diffchecker/.
+ *
+ * The engine decides what the tool shows AND what the merge button writes to
+ * disk, so a wrong answer here is the worst kind of defect: the screen looks
+ * right and the downloaded file is not. Every property below is checked by
+ * comparing whole strings, never counts.
+ *
+ * The cases are generated from a seeded pseudo random source, so a failure is
+ * reproducible: rerun with the seed the report prints.
+ *
+ * Usage: node build/scripts/check-diff-engine.mjs [--seed N] [--cases N]
+ *
+ * @author Ismael Sallami Moreno
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+/**
+ * The engine is a plain browser script, so it is evaluated here rather than
+ * imported: this package is `"type": "module"`, and a `require()` would read
+ * the file as ESM. Passing `window` as undefined makes the script take its
+ * Node branch and hand the API back through `module.exports`.
+ */
+function loadEngine() {
+  const path = resolve(ROOT, "diffchecker/js/diff.js");
+  const shim = { exports: {} };
+  new Function("module", "window", readFileSync(path, "utf8"))(shim, undefined);
+  return shim.exports;
+}
+
+const DIFF = loadEngine();
+
+/** Line endings are normalised to LF, so expectations must be too. */
+const lf = (text) => text.replace(/\r\n?/g, "\n");
+
+/* ------------------------------------------------------------------ *
+ * Seeded random source
+ * ------------------------------------------------------------------ */
+
+/**
+ * mulberry32. Small, fast and good enough to shuffle text around.
+ * @param {number} seed
+ * @returns {() => number}
+ */
+function rng(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const WORDS = [
+  "precio",
+  "total",
+  "if",
+  "return",
+  "función",
+  "año",
+  "café",
+  "\\section",
+  "42",
+  "",
+  "  sangrado",
+  "línea con acentos: ñ á é",
+  "x",
+];
+
+/** @param {() => number} next @returns {string} */
+function randomLine(next) {
+  const count = 1 + Math.floor(next() * 4);
+  const parts = [];
+  for (let i = 0; i < count; i++) {
+    parts.push(WORDS[Math.floor(next() * WORDS.length)]);
+  }
+  return parts.join(" ");
+}
+
+/** @param {() => number} next @param {number} lines @returns {string[]} */
+function randomText(next, lines) {
+  const out = [];
+  for (let i = 0; i < lines; i++) out.push(randomLine(next));
+  return out;
+}
+
+/**
+ * Derives a second version by applying random edits: the realistic shape of
+ * the input, two texts that share most of their lines.
+ * @param {() => number} next
+ * @param {string[]} lines
+ * @returns {string[]}
+ */
+function mutate(next, lines) {
+  const out = lines.slice();
+  const edits = Math.floor(next() * 8);
+
+  for (let i = 0; i < edits; i++) {
+    if (out.length === 0) {
+      out.push(randomLine(next));
+      continue;
+    }
+    const at = Math.floor(next() * out.length);
+    const roll = next();
+
+    if (roll < 0.3) out.splice(at, 0, randomLine(next));
+    else if (roll < 0.6) out.splice(at, 1);
+    else if (roll < 0.85) out[at] = randomLine(next);
+    else {
+      // Move a block: the case a naive line matcher gets wrong.
+      const size = 1 + Math.floor(next() * 3);
+      const block = out.splice(at, size);
+      out.splice(Math.floor(next() * (out.length + 1)), 0, ...block);
+    }
+  }
+
+  return out;
+}
+
+/* ------------------------------------------------------------------ *
+ * Properties
+ * ------------------------------------------------------------------ */
+
+const failures = [];
+
+/**
+ * @param {string} what
+ * @param {boolean} ok
+ * @param {object} context
+ */
+function assert(what, ok, context) {
+  if (ok) return;
+  failures.push({ what, context });
+}
+
+/** Sets the same choice on every hunk. */
+function chooseAll(result, choice) {
+  for (const hunk of result.hunks) hunk.choice = choice;
+  return result;
+}
+
+/**
+ * Runs every property against one pair of texts.
+ * @param {string} label
+ * @param {string} left
+ * @param {string} right
+ * @param {object} [options]
+ */
+function checkPair(label, left, right, options) {
+  const result = DIFF.compare(left, right, options);
+  const context = { label, left, right, options };
+
+  // 1 and 2. The merge is the product the user downloads. Taking one side
+  //          whole has to give that side back, byte for byte.
+  assert(
+    `${label}: todo a la izquierda reproduce el texto izquierdo`,
+    DIFF.merge(chooseAll(result, "left")) === lf(left),
+    context,
+  );
+  assert(
+    `${label}: todo a la derecha reproduce el texto derecho`,
+    DIFF.merge(chooseAll(result, "right")) === lf(right),
+    context,
+  );
+
+  // 3. The rows are the diff itself: reading one side of them in order must
+  //    rebuild that side. This is what proves nothing was dropped.
+  const leftRows = result.rows
+    .filter((row) => row.left.text !== null)
+    .map((row) => row.left.text);
+  const rightRows = result.rows
+    .filter((row) => row.right.text !== null)
+    .map((row) => row.right.text);
+
+  assert(
+    `${label}: las filas reconstruyen el texto izquierdo`,
+    leftRows.join("\n") === lf(left),
+    context,
+  );
+  assert(
+    `${label}: las filas reconstruyen el texto derecho`,
+    rightRows.join("\n") === lf(right),
+    context,
+  );
+
+  // 4. Line numbers must run 1, 2, 3... with no gaps and no repeats, or the
+  //    gutter lies about which line you are looking at.
+  let expected = 0;
+  for (const row of result.rows) {
+    if (row.left.text === null) continue;
+    expected += 1;
+    assert(
+      `${label}: numeración izquierda correlativa`,
+      row.left.n === expected,
+      { ...context, row },
+    );
+  }
+  expected = 0;
+  for (const row of result.rows) {
+    if (row.right.text === null) continue;
+    expected += 1;
+    assert(
+      `${label}: numeración derecha correlativa`,
+      row.right.n === expected,
+      { ...context, row },
+    );
+  }
+
+  // 5. No changes reported if and only if the texts match.
+  const { added, removed, changed } = result.stats;
+  const quiet = added + removed + changed === 0;
+  assert(
+    `${label}: sin cambios si y solo si los textos son iguales`,
+    quiet === (lf(left) === lf(right)),
+    { ...context, stats: result.stats },
+  );
+
+  // 6. Keeping both sides emits every line of both, and nothing else.
+  const equalRows = result.rows.filter((row) => row.hunk === null).length;
+  const bothLines = result.hunks.reduce(
+    (total, hunk) => total + hunk.left.length + hunk.right.length,
+    0,
+  );
+  assert(
+    `${label}: quedarse con ambos lados emite todas las líneas`,
+    DIFF.merge(chooseAll(result, "both")).split("\n").length ===
+      equalRows + bothLines,
+    context,
+  );
+
+  // 7. Hunks must cover disjoint, ordered stretches of rows.
+  let cursor = -1;
+  for (const hunk of result.hunks) {
+    assert(`${label}: bloques ordenados y sin solapar`, hunk.rowStart > cursor, {
+      ...context,
+      hunk,
+    });
+    cursor = hunk.rowEnd;
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Fixed cases
+ * ------------------------------------------------------------------ */
+
+const FIXED = [
+  ["idénticos", "uno\ndos\ntres\n", "uno\ndos\ntres\n"],
+  ["ambos vacíos", "", ""],
+  ["izquierdo vacío", "", "uno\ndos\n"],
+  ["derecho vacío", "uno\ndos\n", ""],
+  ["inserción pura", "uno\ntres\n", "uno\ndos\ntres\n"],
+  ["borrado puro", "uno\ndos\ntres\n", "uno\ntres\n"],
+  ["reemplazo", "uno\ndos\ntres\n", "uno\nDOS\ntres\n"],
+  ["sin salto final", "uno\ndos", "uno\ndos\n"],
+  ["CRLF frente a LF", "uno\r\ndos\r\n", "uno\ndos\n"],
+  ["CR suelto", "uno\rdos\r", "uno\ndos\n"],
+  ["solo saltos", "\n\n\n", "\n\n"],
+  ["acentos", "café\nmañana\n", "café\nmanana\n"],
+  ["líneas repetidas", "x\nx\nx\nx\n", "x\nx\n"],
+  ["bloque movido", "a\nb\nc\nd\ne\n", "d\ne\na\nb\nc\n"],
+  [
+    "nada en común",
+    Array.from({ length: 400 }, (_, i) => `izquierda ${i}`).join("\n"),
+    Array.from({ length: 400 }, (_, i) => `derecha ${i}`).join("\n"),
+  ],
+  [
+    "línea larguísima",
+    "a".repeat(20000) + "\nfin\n",
+    "b".repeat(20000) + "\nfin\n",
+  ],
+];
+
+/* ------------------------------------------------------------------ *
+ * Options
+ * ------------------------------------------------------------------ */
+
+/**
+ * The normalising options change what counts as equal, never what gets
+ * written. A merge always emits the original line, spaces included.
+ */
+function checkOptions() {
+  const left = "uno   dos\n  TRES  \ncuatro\n";
+  const right = "uno dos\nTRES\ncuatro\n";
+
+  const strict = DIFF.compare(left, right);
+  assert(
+    "opciones: sin ignorar nada, el espaciado es una diferencia",
+    strict.stats.added + strict.stats.removed + strict.stats.changed > 0,
+    { left, right },
+  );
+
+  const loose = DIFF.compare(left, right, {
+    ignoreWhitespace: true,
+    trimLines: true,
+  });
+  assert(
+    "opciones: ignorando espacios, los textos son iguales",
+    loose.stats.added + loose.stats.removed + loose.stats.changed === 0,
+    { left, right, stats: loose.stats },
+  );
+  assert(
+    "opciones: el merge devuelve el original, no el normalizado",
+    DIFF.merge(chooseAll(loose, "left")) === lf(left),
+    { left, right },
+  );
+
+  const cased = DIFF.compare("Uno\nDos\n", "uno\ndos\n", { ignoreCase: true });
+  assert(
+    "opciones: ignorando mayúsculas, los textos son iguales",
+    cased.stats.added + cased.stats.removed + cased.stats.changed === 0,
+    { stats: cased.stats },
+  );
+  // Cuando dos líneas solo se distinguen en lo que se ha pedido ignorar no hay
+  // bloque que elegir, así que el merge conserva la izquierda. Eso no puede ser
+  // una sorpresa al descargar: la fila queda marcada para que se vea.
+  assert(
+    "opciones: sin bloque que elegir, el merge conserva la izquierda",
+    DIFF.merge(chooseAll(cased, "right")) === "Uno\nDos\n",
+    { rows: cased.rows.length },
+  );
+  assert(
+    "opciones: las filas iguales solo por la opción quedan marcadas",
+    cased.rows.filter((row) => row.soft).length === 2,
+    { rows: cased.rows },
+  );
+  assert(
+    "opciones: una fila igual de verdad no queda marcada",
+    DIFF.compare("uno\n", "uno\n").rows.every((row) => !row.soft),
+    {},
+  );
+}
+
+/** The word level diff feeds the inline highlight. */
+function checkWords() {
+  const segments = DIFF.words("let total = precio * 1.21;", "let total = precio * IVA;");
+
+  assert(
+    "palabras: los segmentos reconstruyen el lado izquierdo",
+    segments
+      .filter((s) => s.type !== "ins")
+      .map((s) => s.text)
+      .join("") === "let total = precio * 1.21;",
+    { segments },
+  );
+  assert(
+    "palabras: los segmentos reconstruyen el lado derecho",
+    segments
+      .filter((s) => s.type !== "del")
+      .map((s) => s.text)
+      .join("") === "let total = precio * IVA;",
+    { segments },
+  );
+  assert(
+    "palabras: solo se marca lo que cambia, no la línea entera",
+    segments.some((s) => s.type === "eq" && s.text.includes("precio")),
+    { segments },
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Entry point
+ * ------------------------------------------------------------------ */
+
+function main() {
+  const args = process.argv.slice(2);
+  const flag = (name, fallback) => {
+    const at = args.indexOf(name);
+    return at === -1 ? fallback : Number(args[at + 1]);
+  };
+
+  const seed = flag("--seed", 20260814);
+  const cases = flag("--cases", 200);
+
+  for (const [label, left, right] of FIXED) checkPair(`fijo «${label}»`, left, right);
+
+  checkOptions();
+  checkWords();
+
+  const next = rng(seed);
+  for (let i = 0; i < cases; i++) {
+    const size = Math.floor(next() * 60);
+    const left = randomText(next, size);
+    const right = mutate(next, left);
+    const trailing = next() < 0.5 ? "\n" : "";
+
+    checkPair(`azar #${i}`, left.join("\n") + trailing, right.join("\n") + trailing);
+  }
+
+  console.log(
+    `Diff engine: ${FIXED.length} fixed cases, ${cases} random pairs (seed ${seed}), ` +
+      "plus options and word level checks.",
+  );
+
+  if (failures.length === 0) {
+    console.log("Every property holds.");
+    return;
+  }
+
+  console.error(`\n${failures.length} failed:\n`);
+  for (const failure of failures.slice(0, 10)) {
+    console.error(`  ${failure.what}`);
+    console.error(`    ${JSON.stringify(failure.context).slice(0, 400)}\n`);
+  }
+  if (failures.length > 10) {
+    console.error(`  ...and ${failures.length - 10} more.\n`);
+  }
+  console.error(`Reproduce with: node build/scripts/check-diff-engine.mjs --seed ${seed}`);
+  process.exit(1);
+}
+
+main();

--- a/content/sections/tools/section.mjs
+++ b/content/sections/tools/section.mjs
@@ -18,7 +18,7 @@ export default {
   blurb:
     "Pequeñas apps que funcionan al 100% en tu navegador: sin instalar nada y " +
     "sin que tus archivos salgan de tu equipo.",
-  summary: "2 herramientas · sin servidor · código abierto",
+  summary: "3 herramientas · sin servidor · código abierto",
   pages: [],
   links: [
     {
@@ -39,6 +39,11 @@ export default {
     {
       name: "pdf2md · código fuente",
       href: "https://github.com/Ismael-Sallami/pdf-to-md",
+      kind: "WEB",
+    },
+    {
+      name: "diffchecker — comparar dos textos y mezclarlos",
+      href: "/diffchecker/",
       kind: "WEB",
     },
   ],

--- a/diffchecker/assets/favicon.svg
+++ b/diffchecker/assets/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" fill="#eef2ef"/>
+  <rect x="2" y="2" width="28" height="28" fill="none" stroke="#0d0f12" stroke-width="2"/>
+  <rect x="5" y="7" width="9" height="3" fill="#ff5d6c"/>
+  <rect x="5" y="14" width="9" height="3" fill="#0d0f12" opacity="0.25"/>
+  <rect x="5" y="21" width="9" height="3" fill="#0d0f12" opacity="0.25"/>
+  <rect x="18" y="7" width="9" height="3" fill="#0d0f12" opacity="0.25"/>
+  <rect x="18" y="14" width="9" height="3" fill="#4fb31f"/>
+  <rect x="18" y="21" width="9" height="3" fill="#0d0f12" opacity="0.25"/>
+  <rect x="15" y="2" width="2" height="28" fill="#0d0f12"/>
+</svg>

--- a/diffchecker/assets/og-image.svg
+++ b/diffchecker/assets/og-image.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <rect width="1200" height="630" fill="#eef2ef"/>
+  <g stroke="#0d0f12" stroke-width="1" opacity="0.07">
+    <path d="M32 0V630M64 0V630M96 0V630M128 0V630M160 0V630M192 0V630M224 0V630M256 0V630M288 0V630M320 0V630M352 0V630M384 0V630M416 0V630M448 0V630M480 0V630M512 0V630M544 0V630M576 0V630M608 0V630M640 0V630M672 0V630M704 0V630M736 0V630M768 0V630M800 0V630M832 0V630M864 0V630M896 0V630M928 0V630M960 0V630M992 0V630M1024 0V630M1056 0V630M1088 0V630M1120 0V630M1152 0V630M1184 0V630"/>
+    <path d="M0 32H1200M0 64H1200M0 96H1200M0 128H1200M0 160H1200M0 192H1200M0 224H1200M0 256H1200M0 288H1200M0 320H1200M0 352H1200M0 384H1200M0 416H1200M0 448H1200M0 480H1200M0 512H1200M0 544H1200M0 576H1200M0 608H1200"/>
+  </g>
+
+  <rect x="64" y="64" width="1072" height="502" fill="none" stroke="#0d0f12" stroke-width="4"/>
+
+  <rect x="112" y="120" width="196" height="34" fill="#0f9e86"/>
+  <text x="128" y="145" font-family="Manrope, sans-serif" font-size="17" font-weight="700" letter-spacing="3" fill="#07120f">EN TU NAVEGADOR</text>
+
+  <text x="112" y="250" font-family="Bricolage Grotesque, Manrope, sans-serif" font-size="86" font-weight="800" letter-spacing="-2" fill="#0d0f12">DIFFCHECKER</text>
+  <text x="112" y="316" font-family="Manrope, sans-serif" font-size="30" fill="#4a524d">Compara dos textos y quédate con lo mejor de cada uno.</text>
+
+  <g font-family="JetBrains Mono, monospace" font-size="22">
+    <rect x="112" y="368" width="440" height="36" fill="rgba(255,93,108,0.18)"/>
+    <text x="126" y="393" fill="#c22436">− let total = precio * 1.21;</text>
+
+    <rect x="112" y="412" width="440" height="36" fill="rgba(0,0,0,0.04)"/>
+    <text x="126" y="437" fill="#4a524d">  return total;</text>
+
+    <rect x="648" y="368" width="440" height="36" fill="rgba(79,179,31,0.2)"/>
+    <text x="662" y="393" fill="#2f7a0f">+ let total = precio * IVA;</text>
+
+    <rect x="648" y="412" width="440" height="36" fill="rgba(0,0,0,0.04)"/>
+    <text x="662" y="437" fill="#4a524d">  return total;</text>
+  </g>
+
+  <rect x="576" y="360" width="4" height="96" fill="#0d0f12"/>
+  <text x="588" y="398" font-family="Manrope, sans-serif" font-size="26" font-weight="700" fill="#0d0f12">▶</text>
+
+  <text x="112" y="512" font-family="Manrope, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#4a524d">ELBLOGDEISMAEL.GITHUB.IO — ISMAEL SALLAMI</text>
+</svg>

--- a/diffchecker/index.html
+++ b/diffchecker/index.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <title>diffchecker · Comparar dos textos y mezclarlos | El Blog de Ismael</title>
+  <meta name="description" content="Compara dos textos o dos ficheros línea a línea, con las diferencias resaltadas palabra a palabra, y construye una versión final quedándote con el lado que quieras de cada bloque. Funciona entero en tu navegador: nada se sube a ningún sitio." />
+  <meta name="keywords" content="comparar textos, diff online, diferencias entre dos archivos, mezclar textos, merge de texto, comparador de ficheros, diff en el navegador" />
+  <meta name="author" content="Ismael Sallami" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://elblogdeismael.github.io/diffchecker/" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="es_ES" />
+  <meta property="og:url" content="https://elblogdeismael.github.io/diffchecker/" />
+  <meta property="og:title" content="diffchecker · Comparar dos textos y mezclarlos" />
+  <meta property="og:description" content="Las diferencias resaltadas palabra a palabra y un botón por bloque para quedarte con la versión que quieras. Gratis y en tu navegador." />
+  <meta property="og:image" content="https://elblogdeismael.github.io/diffchecker/assets/og-image.svg" />
+  <meta property="og:site_name" content="El Blog de Ismael" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="diffchecker · Comparar dos textos y mezclarlos" />
+  <meta name="twitter:description" content="Compara dos textos, mézclalos bloque a bloque y descarga el resultado. Sin subir nada a ningún servidor." />
+  <meta name="twitter:image" content="https://elblogdeismael.github.io/diffchecker/assets/og-image.svg" />
+
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
+
+  <!-- Google Analytics (mismo dominio del blog) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-5W0LVJ83W7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-5W0LVJ83W7');
+  </script>
+
+  <!-- JSON-LD: WebApplication -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "diffchecker — Comparar y mezclar dos textos",
+    "url": "https://elblogdeismael.github.io/diffchecker/",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Any (navegador web)",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" },
+    "inLanguage": "es",
+    "author": { "@type": "Person", "name": "Ismael Sallami" },
+    "description": "Compara dos textos o ficheros línea a línea, resalta las diferencias palabra a palabra y permite construir una versión final eligiendo bloque a bloque con qué lado quedarse. Todo el proceso ocurre en el navegador."
+  }
+  </script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,700;12..96,800&family=Manrope:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" />
+  <link rel="stylesheet" href="/assets/css/tool.css" />
+</head>
+<body class="light">
+  <div class="bg-grid" aria-hidden="true"></div>
+
+  <a class="skip-link" href="#app">Saltar al comparador</a>
+
+  <header class="site-header">
+    <a class="brand" href="https://elblogdeismael.github.io/">
+      <span class="brand-mark">&lt;/&gt;</span>
+      <span>El Blog de Ismael</span>
+    </a>
+    <nav class="header-links">
+      <a href="https://elblogdeismael.github.io/">Inicio</a>
+      <a href="https://elblogdeismael.github.io/tools/">Herramientas</a>
+      <button id="theme-toggle" class="ghost-btn" title="Cambiar tema de la página">🌙</button>
+    </nav>
+  </header>
+
+  <section class="hero">
+    <div class="hero-badge">100% en tu navegador · sin subir nada · gratis</div>
+    <h1>Compara dos textos y <span class="grad">quédate</span> con <span class="grad2">lo mejor de cada uno</span></h1>
+    <p class="hero-sub">
+      Pega o arrastra dos versiones de lo que sea —un apunte, un <code>.tex</code>, un
+      fichero de código— y verás en qué se diferencian, línea a línea y palabra a palabra.
+      Después, con <code>◀</code> y <code>▶</code>, decides bloque a bloque con qué lado te
+      quedas y te llevas el resultado.
+    </p>
+  </section>
+
+  <main class="diff-app" id="app">
+    <div class="diff-bar">
+      <div class="segmented" role="group" aria-label="Vista">
+        <button class="seg-btn" id="view-edit" aria-pressed="true">Editar</button>
+        <button class="seg-btn" id="view-diff" aria-pressed="false">Diferencias</button>
+        <button class="seg-btn" id="view-result" aria-pressed="false">Resultado</button>
+      </div>
+
+      <button class="ghost-btn small" id="prev-change" title="Cambio anterior (Alt + flecha arriba)" aria-label="Ir al cambio anterior">‹</button>
+      <button class="ghost-btn small" id="next-change" title="Cambio siguiente (Alt + flecha abajo)" aria-label="Ir al cambio siguiente">›</button>
+
+      <p class="dstat" id="stats" aria-hidden="true">
+        <span class="is-same">Pega algo en los dos lados</span>
+      </p>
+
+      <span class="spacer"></span>
+
+      <div class="segmented" role="group" aria-label="Disposición">
+        <button class="seg-btn" id="layout-split" aria-pressed="true">Lado a lado</button>
+        <button class="seg-btn" id="layout-unified" aria-pressed="false">Unificada</button>
+      </div>
+
+      <button class="ghost-btn small" id="all-left" title="Quedarme con la izquierda en todos los bloques">◀ Todo</button>
+      <button class="ghost-btn small" id="all-right" title="Quedarme con la derecha en todos los bloques">Todo ▶</button>
+      <button class="ghost-btn small" id="reset-choices" title="Volver a la elección inicial">↺</button>
+
+      <span class="bar-break"></span>
+
+      <label class="switch"><input type="checkbox" id="opt-ws" /> Ignorar espacios</label>
+      <label class="switch"><input type="checkbox" id="opt-case" /> Ignorar mayúsculas</label>
+      <label class="switch"><input type="checkbox" id="opt-trim" /> Recortar líneas</label>
+
+      <span class="spacer"></span>
+
+      <button class="ghost-btn small" id="swap">⇄ Intercambiar</button>
+      <button class="ghost-btn small" id="example">Ejemplo</button>
+      <button class="ghost-btn small" id="clear-all">Limpiar</button>
+    </div>
+
+    <p class="note" id="notice" hidden></p>
+
+    <!-- Vista: editar -->
+    <section class="editor-grid" id="panel-edit">
+      <div class="editor">
+        <div class="editor-head">
+          <h2>Original</h2>
+          <span class="fname" id="name-left">texto pegado</span>
+        </div>
+        <label class="visually-hidden" for="text-left">Texto original</label>
+        <textarea id="text-left" spellcheck="false" autocomplete="off"
+          placeholder="Pega aquí la primera versión, o arrastra un fichero sobre la zona de abajo."></textarea>
+        <div class="dropzone" id="drop-left" tabindex="0" role="button"
+          aria-label="Cargar un fichero en el lado original">
+          <p class="dz-or">Arrastra un fichero o <span class="link">búscalo en tu equipo</span></p>
+          <p class="dz-formats">.txt .md .tex .csv .json y cualquier otro fichero de texto</p>
+          <input type="file" id="file-left" hidden />
+        </div>
+      </div>
+
+      <div class="editor">
+        <div class="editor-head">
+          <h2>Modificado</h2>
+          <span class="fname" id="name-right">texto pegado</span>
+        </div>
+        <label class="visually-hidden" for="text-right">Texto modificado</label>
+        <textarea id="text-right" spellcheck="false" autocomplete="off"
+          placeholder="Y aquí la segunda. La comparación se actualiza sola mientras escribes."></textarea>
+        <div class="dropzone" id="drop-right" tabindex="0" role="button"
+          aria-label="Cargar un fichero en el lado modificado">
+          <p class="dz-or">Arrastra un fichero o <span class="link">búscalo en tu equipo</span></p>
+          <p class="dz-formats">.txt .md .tex .csv .json y cualquier otro fichero de texto</p>
+          <input type="file" id="file-right" hidden />
+        </div>
+      </div>
+    </section>
+
+    <!-- Vista: diferencias -->
+    <section id="panel-diff" hidden>
+      <div class="diff-grid" id="grid"></div>
+    </section>
+
+    <!-- Vista: resultado -->
+    <section id="panel-result" hidden>
+      <div class="actions">
+        <button class="primary-btn" id="copy-result">Copiar resultado</button>
+        <button class="secondary-btn" id="download-result">Descargar</button>
+      </div>
+      <div class="result-pane">
+        <pre id="result-text"></pre>
+      </div>
+    </section>
+
+    <p class="visually-hidden" id="announce" aria-live="polite"></p>
+  </main>
+
+  <section class="howto">
+    <h2>Cómo se usa</h2>
+    <div class="howto-grid">
+      <div class="card">
+        <h3>Comparar</h3>
+        <p>
+          Pega las dos versiones o arrastra un fichero a cada lado. La comparación se
+          recalcula sola. Dentro de una línea que cambia se marca solo lo que cambia,
+          no la línea entera.
+        </p>
+      </div>
+
+      <div class="card">
+        <h3>Mezclar</h3>
+        <p>
+          El resultado <strong>parte del lado original</strong>. Cada bloque en conflicto
+          trae tres botones: <code>◀</code> se queda con el original, <code>▶</code> con
+          el modificado y <code>◀▶</code> con los dos, uno detrás de otro. Cuando lo tengas,
+          la pestaña <em>Resultado</em> lo copia o lo descarga.
+        </p>
+      </div>
+
+      <div class="card">
+        <h3>Atajos</h3>
+        <ul>
+          <li><code>Alt</code> + <code>↓</code> / <code>↑</code> — cambio siguiente o anterior</li>
+          <li><code>Alt</code> + <code>←</code> / <code>→</code> — quedarme con ese lado</li>
+          <li>Un clic en <code>··· líneas iguales ···</code> despliega el tramo</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h3>Lo que conviene saber</h3>
+        <ul>
+          <li>Los ficheros no salen de tu equipo: todo ocurre en el navegador.</li>
+          <li>Los finales de línea se normalizan a <code>LF</code> al descargar.</li>
+          <li>Al ignorar espacios o mayúsculas, las líneas que solo se distinguen en eso
+            salen con subrayado de puntos: el resultado conserva la del original.</li>
+          <li>Tope de 5&nbsp;MB por fichero y de 30.000 líneas entre los dos.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <p>
+      Hecho por <a href="https://github.com/Ismael-Sallami" target="_blank" rel="noopener">Ismael Sallami</a> ·
+      Parte de <a href="https://elblogdeismael.github.io/">El Blog de Ismael</a>
+    </p>
+  </footer>
+
+  <script src="js/diff.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/diffchecker/js/app.js
+++ b/diffchecker/js/app.js
@@ -1,0 +1,861 @@
+/**
+ * Interfaz de /diffchecker/.
+ *
+ * El motor (js/diff.js) decide que cambia; esto solo lo pinta y recoge las
+ * elecciones del merge. Nada de innerHTML con texto del usuario: cada celda se
+ * construye con createElement y textContent, que es lo unico que garantiza que
+ * pegar un fragmento de HTML no ejecute nada.
+ *
+ * @author Ismael Sallami Moreno
+ */
+
+(function () {
+  "use strict";
+
+  var $ = function (id) {
+    return document.getElementById(id);
+  };
+
+  /** Tramos iguales mas largos que esto se pliegan, dejando contexto. */
+  var FOLD_MIN = 8;
+  var CONTEXT = 3;
+
+  var state = {
+    view: "edit",
+    layout: "split",
+    // Lo que ha elegido el usuario, que no siempre es lo que se muestra: en
+    // pantalla estrecha se fuerza la unificada y al ensanchar se devuelve
+    // esto, no un valor por defecto.
+    preferredLayout: "split",
+    result: null,
+    current: -1,
+    expanded: Object.create(null),
+    // Bloques que el usuario ha resuelto. Atenuar un lado tiene que
+    // significar «he decidido», no «este es el valor inicial»: si no, la
+    // vista nace con media pantalla apagada y comparar cuesta mas.
+    decided: Object.create(null),
+    names: { left: "", right: "" },
+  };
+
+  var timer = null;
+
+  /* ---------------------------------------------------------------- *
+   * Tema de la pagina (claro/oscuro)
+   * ---------------------------------------------------------------- */
+
+  (function initPageTheme() {
+    var saved = localStorage.getItem("diffchecker_theme");
+    if (saved === "dark") {
+      document.body.classList.remove("light");
+    } else {
+      document.body.classList.add("light");
+      if (!saved) localStorage.setItem("diffchecker_theme", "light");
+    }
+
+    var btn = $("theme-toggle");
+    function paint() {
+      btn.textContent = document.body.classList.contains("light") ? "☀️" : "🌙";
+    }
+    paint();
+    btn.addEventListener("click", function () {
+      document.body.classList.toggle("light");
+      localStorage.setItem(
+        "diffchecker_theme",
+        document.body.classList.contains("light") ? "light" : "dark",
+      );
+      paint();
+    });
+  })();
+
+  /* ---------------------------------------------------------------- *
+   * Utilidades de DOM
+   * ---------------------------------------------------------------- */
+
+  function el(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  function say(message) {
+    $("announce").textContent = message;
+  }
+
+  function notice(message) {
+    var box = $("notice");
+    if (!message) {
+      box.hidden = true;
+      box.textContent = "";
+      return;
+    }
+    box.hidden = false;
+    box.textContent = message;
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Comparacion
+   * ---------------------------------------------------------------- */
+
+  function options() {
+    return {
+      ignoreWhitespace: $("opt-ws").checked,
+      ignoreCase: $("opt-case").checked,
+      trimLines: $("opt-trim").checked,
+    };
+  }
+
+  function recompute() {
+    var left = $("text-left").value;
+    var right = $("text-right").value;
+
+    if (left === "" && right === "") {
+      state.result = null;
+      state.current = -1;
+      state.expanded = Object.create(null);
+      notice("");
+      paintStats();
+      render();
+      return;
+    }
+
+    try {
+      state.result = DIFF.compare(left, right, options());
+      notice(
+        state.result.truncated
+          ? "Los dos textos se parecen tan poco que un tramo se ha marcado entero " +
+              "como reemplazo. La comparación sigue siendo exacta: nada se pierde al mezclar."
+          : "",
+      );
+    } catch (error) {
+      state.result = null;
+      notice(error.message);
+    }
+
+    state.current = -1;
+    state.expanded = Object.create(null);
+    state.decided = Object.create(null);
+    paintStats();
+    render();
+  }
+
+  function schedule() {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(recompute, 300);
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Contador de cambios
+   * ---------------------------------------------------------------- */
+
+  function paintStats() {
+    var box = $("stats");
+    box.textContent = "";
+
+    if (!state.result) {
+      box.appendChild(el("span", "is-same", "Pega algo en los dos lados"));
+      return;
+    }
+
+    var stats = state.result.stats;
+    if (stats.added + stats.removed + stats.changed === 0) {
+      box.appendChild(el("span", "is-same", "Los dos textos son idénticos"));
+      return;
+    }
+
+    if (stats.changed) {
+      box.appendChild(el("b", null, String(stats.changed)));
+      box.appendChild(el("span", null, "modificadas"));
+    }
+    if (stats.added) {
+      box.appendChild(el("b", "is-add", "+" + stats.added));
+      box.appendChild(el("span", "is-add", "añadidas"));
+    }
+    if (stats.removed) {
+      box.appendChild(el("b", "is-del", "−" + stats.removed));
+      box.appendChild(el("span", "is-del", "eliminadas"));
+    }
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Celdas
+   * ---------------------------------------------------------------- */
+
+  /**
+   * Celda de texto. Con detalle por palabras se envuelve en <mark> solo lo que
+   * cambia; sin el, la linea va tal cual.
+   */
+  function textCell(side, row) {
+    var cell = el("span", "dtext side-" + (side === "left" ? "l" : "r"));
+    var value = row[side].text;
+
+    if (value === null) {
+      cell.classList.add("dpad");
+      return cell;
+    }
+    if (!row.words) {
+      cell.textContent = value;
+      return cell;
+    }
+
+    var skip = side === "left" ? "ins" : "del";
+    var markClass = side === "left" ? "wdel" : "wadd";
+
+    for (var i = 0; i < row.words.length; i++) {
+      var segment = row.words[i];
+      if (segment.type === skip) continue;
+      if (segment.type === "eq") {
+        cell.appendChild(document.createTextNode(segment.text));
+      } else {
+        cell.appendChild(el("mark", markClass, segment.text));
+      }
+    }
+    return cell;
+  }
+
+  function numberCell(side, value) {
+    var cell = el(
+      "span",
+      "dnum side-" + (side === "left" ? "l" : "r"),
+      value === null ? "" : String(value),
+    );
+    if (value === null) cell.classList.add("dpad");
+    return cell;
+  }
+
+  function signCell(side, row) {
+    var mark = "";
+    if (side === "left" && row.left.text !== null) {
+      if (row.type === "remove" || row.type === "change") mark = "−";
+    }
+    if (side === "right" && row.right.text !== null) {
+      if (row.type === "add" || row.type === "change") mark = "+";
+    }
+    var cell = el("span", "dsign side-" + (side === "left" ? "l" : "r"), mark);
+    if (row[side].text === null) cell.classList.add("dpad");
+    return cell;
+  }
+
+  var CHOICES = [
+    ["left", "◀", "quedarme con el original"],
+    ["right", "▶", "quedarme con el modificado"],
+    ["both", "◀▶", "quedarme con los dos"],
+  ];
+
+  /** Los botones de eleccion, solo en la primera fila de cada bloque. */
+  function mergeCell(hunk, first) {
+    var cell = el("span", "dmerge");
+    if (!first) return cell;
+
+    for (var i = 0; i < CHOICES.length; i++) {
+      var choice = CHOICES[i][0];
+      var button = el("button", "hunk-btn", CHOICES[i][1]);
+      button.type = "button";
+      button.dataset.hunk = String(hunk.id);
+      button.dataset.choice = choice;
+      button.setAttribute("aria-pressed", hunk.choice === choice ? "true" : "false");
+      button.setAttribute(
+        "aria-label",
+        "Bloque " + (hunk.id + 1) + ": " + CHOICES[i][2],
+      );
+      button.title = CHOICES[i][2];
+      cell.appendChild(button);
+    }
+    return cell;
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Filas
+   * ---------------------------------------------------------------- */
+
+  function splitRow(row, index) {
+    var node = el("div", "drow " + row.type + (row.soft ? " soft" : ""));
+    var hunk = row.hunk === null ? null : state.result.hunks[row.hunk];
+
+    if (hunk) {
+      node.dataset.hunk = String(hunk.id);
+      if (state.decided[hunk.id]) node.dataset.choice = hunk.choice;
+      if (hunk.id === state.current) node.classList.add("current");
+    }
+
+    node.appendChild(numberCell("left", row.left.n));
+    node.appendChild(signCell("left", row));
+    node.appendChild(textCell("left", row));
+    node.appendChild(hunk ? mergeCell(hunk, index === hunk.rowStart) : el("span", "dmerge"));
+    node.appendChild(numberCell("right", row.right.n));
+    node.appendChild(signCell("right", row));
+    node.appendChild(textCell("right", row));
+    return node;
+  }
+
+  /**
+   * En la vista unificada cada linea ocupa su propia fila: primero lo que sale
+   * del bloque y despues lo que entra.
+   */
+  function unifiedRow(row, side, hunk, first) {
+    var kind = side === "left" ? (row.type === "eq" ? "eq" : "remove") : "add";
+    var node = el("div", "drow " + kind + (row.soft ? " soft" : ""));
+
+    if (hunk) {
+      node.dataset.hunk = String(hunk.id);
+      if (state.decided[hunk.id]) node.dataset.choice = hunk.choice;
+      if (hunk.id === state.current) node.classList.add("current");
+    }
+
+    node.appendChild(numberCell("left", side === "right" ? null : row.left.n));
+    node.appendChild(numberCell("right", side === "left" ? null : row.right.n));
+
+    var mark = row.type === "eq" ? "" : side === "left" ? "−" : "+";
+    node.appendChild(
+      el("span", "dsign side-" + (side === "left" ? "l" : "r"), mark),
+    );
+
+    // La misma celda que la vista lado a lado, para que el resaltado palabra a
+    // palabra no se pierda al pasar a unificada.
+    node.appendChild(textCell(side, row));
+    node.appendChild(hunk ? mergeCell(hunk, first) : el("span", "dmerge"));
+    return node;
+  }
+
+  function foldRow(from, hidden) {
+    var button = el(
+      "button",
+      "dfold",
+      "··· " + hidden + (hidden === 1 ? " línea igual" : " líneas iguales") + " ···",
+    );
+    button.type = "button";
+    button.dataset.fold = String(from);
+    button.title = "Mostrar este tramo";
+    return button;
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Pintado
+   * ---------------------------------------------------------------- */
+
+  function emit(fragment, row, index) {
+    if (state.layout === "split") {
+      fragment.appendChild(splitRow(row, index));
+      return;
+    }
+
+    var hunk = row.hunk === null ? null : state.result.hunks[row.hunk];
+    var first = hunk ? index === hunk.rowStart : false;
+    var hasLeft = row.left.text !== null;
+
+    if (hasLeft) {
+      fragment.appendChild(unifiedRow(row, "left", hunk, first));
+    }
+    if (row.right.text !== null && row.type !== "eq") {
+      // Un bloque que solo anade no tiene linea izquierda, asi que los botones
+      // de eleccion tienen que ir en la primera linea de la derecha o ese
+      // bloque se quedaria sin ellos.
+      fragment.appendChild(unifiedRow(row, "right", hunk, first && !hasLeft));
+    }
+  }
+
+  function renderDiff() {
+    var grid = $("grid");
+    grid.textContent = "";
+    grid.classList.toggle("unified", state.layout === "unified");
+
+    if (!state.result) {
+      var empty = el("div", "diff-empty");
+      empty.appendChild(el("strong", null, "Nada que comparar todavía"));
+      empty.appendChild(
+        el("p", null, "Escribe o carga un fichero en cada lado y esto se llena solo."),
+      );
+      grid.appendChild(empty);
+      return;
+    }
+
+    var rows = state.result.rows;
+    var fragment = document.createDocumentFragment();
+    var i = 0;
+
+    while (i < rows.length) {
+      if (rows[i].hunk !== null) {
+        emit(fragment, rows[i], i);
+        i++;
+        continue;
+      }
+
+      // Tramo de lineas iguales: se pliega si es largo, dejando contexto a los
+      // lados para no perder de vista donde estaba el cambio.
+      var end = i;
+      while (end < rows.length && rows[end].hunk === null) end++;
+
+      var before = i === 0 ? 0 : CONTEXT;
+      var after = end === rows.length ? 0 : CONTEXT;
+      var hidden = end - i - before - after;
+
+      if (hidden < FOLD_MIN || state.expanded[i]) {
+        for (var k = i; k < end; k++) emit(fragment, rows[k], k);
+        i = end;
+        continue;
+      }
+
+      for (var a = i; a < i + before; a++) emit(fragment, rows[a], a);
+      fragment.appendChild(foldRow(i, hidden));
+      for (var b = end - after; b < end; b++) emit(fragment, rows[b], b);
+      i = end;
+    }
+
+    grid.appendChild(fragment);
+  }
+
+  function renderResult() {
+    $("result-text").textContent = state.result ? DIFF.merge(state.result) : "";
+  }
+
+  function render() {
+    $("panel-edit").hidden = state.view !== "edit";
+    $("panel-diff").hidden = state.view !== "diff";
+    $("panel-result").hidden = state.view !== "result";
+
+    $("view-edit").setAttribute("aria-pressed", String(state.view === "edit"));
+    $("view-diff").setAttribute("aria-pressed", String(state.view === "diff"));
+    $("view-result").setAttribute("aria-pressed", String(state.view === "result"));
+    $("layout-split").setAttribute("aria-pressed", String(state.layout === "split"));
+    $("layout-unified").setAttribute("aria-pressed", String(state.layout === "unified"));
+
+    var idle = !state.result || state.result.hunks.length === 0;
+    ["prev-change", "next-change", "all-left", "all-right", "reset-choices"].forEach(
+      function (id) {
+        $(id).disabled = idle;
+      },
+    );
+
+    if (state.view === "diff") renderDiff();
+    if (state.view === "result") renderResult();
+  }
+
+  function setView(view) {
+    state.view = view;
+    render();
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Elecciones del merge
+   * ---------------------------------------------------------------- */
+
+  function choose(id, choice) {
+    if (!state.result) return;
+    state.result.hunks[id].choice = choice;
+    state.decided[id] = true;
+
+    // Repintar solo las filas del bloque: con un diff largo, rehacer la rejilla
+    // entera a cada clic se nota.
+    var rows = $("grid").querySelectorAll('[data-hunk="' + id + '"]');
+    for (var i = 0; i < rows.length; i++) {
+      if (rows[i].classList.contains("drow")) rows[i].dataset.choice = choice;
+      else rows[i].setAttribute("aria-pressed", String(rows[i].dataset.choice === choice));
+    }
+
+    var label = choice === "left" ? "el original" : choice === "right" ? "el modificado" : "los dos";
+    say("Bloque " + (id + 1) + ": " + label);
+  }
+
+  function chooseAll(choice, decided) {
+    if (!state.result) return;
+    for (var i = 0; i < state.result.hunks.length; i++) {
+      state.result.hunks[i].choice = choice;
+      if (decided) state.decided[i] = true;
+    }
+    if (!decided) state.decided = Object.create(null);
+    render();
+    say(
+      "Todos los bloques: " +
+        (choice === "left" ? "el original" : "el modificado") +
+        ".",
+    );
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Navegacion entre bloques
+   * ---------------------------------------------------------------- */
+
+  function goTo(step) {
+    if (!state.result || state.result.hunks.length === 0) return;
+
+    var total = state.result.hunks.length;
+    var next = state.current + step;
+    if (next < 0) next = total - 1;
+    if (next >= total) next = 0;
+    state.current = next;
+
+    if (state.view !== "diff") setView("diff");
+    else renderDiff();
+
+    var node = $("grid").querySelector('[data-hunk="' + next + '"]');
+    if (node) node.scrollIntoView({ block: "center", behavior: "smooth" });
+    say("Bloque " + (next + 1) + " de " + total + ".");
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Ficheros
+   * ---------------------------------------------------------------- */
+
+  function loadFile(side, file) {
+    if (!file) return;
+
+    if (file.size > DIFF.LIMITS.maxBytes) {
+      notice(
+        "«" + file.name + "» pesa más de " +
+          Math.round(DIFF.LIMITS.maxBytes / (1024 * 1024)) +
+          " MB, que es el tope de esta herramienta.",
+      );
+      return;
+    }
+
+    file.text().then(function (text) {
+      // Un binario leido como texto pinta basura y no dice por que. Los bytes
+      // nulos lo delatan antes de tocar nada.
+      if (text.indexOf("\u0000") !== -1) {
+        notice("«" + file.name + "» no parece un fichero de texto.");
+        return;
+      }
+
+      $(side === "left" ? "text-left" : "text-right").value = text;
+      state.names[side] = file.name;
+      $(side === "left" ? "name-left" : "name-right").textContent = file.name;
+      notice("");
+      recompute();
+
+      if ($("text-left").value && $("text-right").value) setView("diff");
+    });
+  }
+
+  function wireDropzone(side) {
+    var zone = $(side === "left" ? "drop-left" : "drop-right");
+    var input = $(side === "left" ? "file-left" : "file-right");
+
+    zone.addEventListener("click", function () {
+      input.click();
+    });
+    zone.addEventListener("keydown", function (event) {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        input.click();
+      }
+    });
+    input.addEventListener("change", function () {
+      loadFile(side, input.files[0]);
+      input.value = "";
+    });
+
+    ["dragenter", "dragover"].forEach(function (name) {
+      zone.addEventListener(name, function (event) {
+        event.preventDefault();
+        zone.classList.add("dragover");
+      });
+    });
+    ["dragleave", "drop"].forEach(function (name) {
+      zone.addEventListener(name, function (event) {
+        event.preventDefault();
+        zone.classList.remove("dragover");
+      });
+    });
+    zone.addEventListener("drop", function (event) {
+      loadFile(side, event.dataTransfer.files[0]);
+    });
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Resultado
+   * ---------------------------------------------------------------- */
+
+  function outputName() {
+    var name = state.names.left || state.names.right;
+    if (!name) return "resultado.txt";
+    var dot = name.lastIndexOf(".");
+    return dot > 0
+      ? name.slice(0, dot) + "-mezclado" + name.slice(dot)
+      : name + "-mezclado.txt";
+  }
+
+  function download() {
+    if (!state.result) return;
+    var blob = new Blob([DIFF.merge(state.result)], {
+      type: "text/plain;charset=utf-8",
+    });
+    var url = URL.createObjectURL(blob);
+    var link = document.createElement("a");
+    link.href = url;
+    link.download = outputName();
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setTimeout(function () {
+      URL.revokeObjectURL(url);
+    }, 1000);
+  }
+
+  function copy() {
+    if (!state.result) return;
+    var text = DIFF.merge(state.result);
+    var button = $("copy-result");
+
+    function done() {
+      button.textContent = "Copiado";
+      setTimeout(function () {
+        button.textContent = "Copiar resultado";
+      }, 1600);
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(done, fallback);
+    } else {
+      fallback();
+    }
+
+    function fallback() {
+      var area = document.createElement("textarea");
+      area.value = text;
+      area.setAttribute("readonly", "");
+      area.style.position = "fixed";
+      area.style.opacity = "0";
+      document.body.appendChild(area);
+      area.select();
+      try {
+        document.execCommand("copy");
+        done();
+      } catch (error) {
+        notice("El navegador no ha dejado copiar. Selecciona el texto a mano.");
+      }
+      document.body.removeChild(area);
+    }
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Ejemplo
+   * ---------------------------------------------------------------- */
+
+  var EXAMPLE_LEFT =
+    "# Análisis de los estados financieros\n" +
+    "\n" +
+    "## Ratio de liquidez\n" +
+    "\n" +
+    "El ratio de liquidez mide la capacidad de la empresa para atender sus\n" +
+    "deudas a corto plazo. Se calcula asi:\n" +
+    "\n" +
+    "    liquidez = activo corriente / pasivo corriente\n" +
+    "\n" +
+    "Un valor por debajo de 1 indica que la empresa no puede cubrir sus\n" +
+    "obligaciones inmediatas con lo que tiene disponible.\n" +
+    "\n" +
+    "## Fondo de maniobra\n" +
+    "\n" +
+    "Es la diferencia entre el activo corriente y el pasivo corriente.\n";
+
+  var EXAMPLE_RIGHT =
+    "# Análisis de los estados financieros\n" +
+    "\n" +
+    "## Ratio de liquidez\n" +
+    "\n" +
+    "El ratio de liquidez mide la capacidad de la empresa para atender sus\n" +
+    "deudas a corto plazo. Se calcula así:\n" +
+    "\n" +
+    "$$ \\text{liquidez} = \\frac{\\text{activo corriente}}{\\text{pasivo corriente}} $$\n" +
+    "\n" +
+    "Un valor por debajo de 1 indica que la empresa no puede cubrir sus\n" +
+    "obligaciones inmediatas con lo que tiene disponible.\n" +
+    "\n" +
+    "## Fondo de maniobra\n" +
+    "\n" +
+    "Es la diferencia entre el activo corriente y el pasivo corriente. Un fondo\n" +
+    "de maniobra negativo suele anticipar tensiones de tesorería.\n" +
+    "\n" +
+    "## Ratio de endeudamiento\n" +
+    "\n" +
+    "Relaciona los recursos ajenos con el total del pasivo.\n";
+
+  function loadExample() {
+    $("text-left").value = EXAMPLE_LEFT;
+    $("text-right").value = EXAMPLE_RIGHT;
+    state.names.left = "apuntes.md";
+    state.names.right = "apuntes-revisado.md";
+    $("name-left").textContent = "apuntes.md";
+    $("name-right").textContent = "apuntes-revisado.md";
+    recompute();
+    setView("diff");
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Cableado
+   * ---------------------------------------------------------------- */
+
+  /**
+   * La barra se pega justo debajo de la cabecera, y la altura de la cabecera
+   * depende de la tipografia, del ancho y del tamano de letra del navegador.
+   * Medirla es lo unico que no envejece: una constante en el CSS deja una
+   * costura en cuanto algo de eso cambia.
+   */
+  function syncHeaderHeight() {
+    var header = document.querySelector(".site-header");
+    if (!header) return;
+    document.documentElement.style.setProperty(
+      "--header-h",
+      Math.round(header.getBoundingClientRect().height) + "px",
+    );
+  }
+
+  /**
+   * Lado a lado necesita ancho: por debajo de 900px cada linea cae en dos
+   * columnas de unas ocho letras y deja de servir para lo unico que sirve,
+   * que es leer las dos versiones a la vez. Ahi se fuerza la unificada.
+   */
+  var narrow = window.matchMedia("(max-width: 900px)");
+
+  function applyWidth() {
+    var forced = narrow.matches;
+    var button = $("layout-split");
+    button.disabled = forced;
+    button.title = forced
+      ? "La vista lado a lado necesita una pantalla más ancha"
+      : "";
+
+    var wanted = forced ? "unified" : state.preferredLayout;
+    if (wanted !== state.layout) {
+      state.layout = wanted;
+      render();
+    } else {
+      $("layout-split").setAttribute("aria-pressed", String(state.layout === "split"));
+      $("layout-unified").setAttribute("aria-pressed", String(state.layout === "unified"));
+    }
+  }
+
+  function wire() {
+    ["text-left", "text-right"].forEach(function (id) {
+      $(id).addEventListener("input", schedule);
+      $(id).addEventListener("paste", function () {
+        // Pegar es el gesto que termina la edicion: en cuanto los dos lados
+        // tienen algo, se salta a las diferencias sin pedirlo.
+        setTimeout(function () {
+          recompute();
+          if ($("text-left").value && $("text-right").value) setView("diff");
+        }, 0);
+      });
+    });
+
+    ["opt-ws", "opt-case", "opt-trim"].forEach(function (id) {
+      $(id).addEventListener("change", recompute);
+    });
+
+    $("view-edit").addEventListener("click", function () {
+      setView("edit");
+    });
+    $("view-diff").addEventListener("click", function () {
+      setView("diff");
+    });
+    $("view-result").addEventListener("click", function () {
+      setView("result");
+    });
+
+    $("layout-split").addEventListener("click", function () {
+      state.preferredLayout = "split";
+      applyWidth();
+    });
+    $("layout-unified").addEventListener("click", function () {
+      state.preferredLayout = "unified";
+      applyWidth();
+    });
+
+    $("all-left").addEventListener("click", function () {
+      chooseAll("left", true);
+    });
+    $("all-right").addEventListener("click", function () {
+      chooseAll("right", true);
+    });
+    $("reset-choices").addEventListener("click", function () {
+      chooseAll("left", false);
+      say("Elecciones reiniciadas.");
+    });
+
+    $("prev-change").addEventListener("click", function () {
+      goTo(-1);
+    });
+    $("next-change").addEventListener("click", function () {
+      goTo(1);
+    });
+
+    $("swap").addEventListener("click", function () {
+      var left = $("text-left").value;
+      $("text-left").value = $("text-right").value;
+      $("text-right").value = left;
+
+      var name = state.names.left;
+      state.names.left = state.names.right;
+      state.names.right = name;
+      $("name-left").textContent = state.names.left || "texto pegado";
+      $("name-right").textContent = state.names.right || "texto pegado";
+
+      recompute();
+      say("Lados intercambiados.");
+    });
+
+    $("clear-all").addEventListener("click", function () {
+      $("text-left").value = "";
+      $("text-right").value = "";
+      state.names = { left: "", right: "" };
+      $("name-left").textContent = "texto pegado";
+      $("name-right").textContent = "texto pegado";
+      recompute();
+      setView("edit");
+    });
+
+    $("example").addEventListener("click", loadExample);
+    $("copy-result").addEventListener("click", copy);
+    $("download-result").addEventListener("click", download);
+
+    // Un solo oyente para toda la rejilla: con miles de filas, poner un oyente
+    // por boton es lo que hace que la vista tarde en aparecer.
+    $("grid").addEventListener("click", function (event) {
+      var button = event.target.closest("button");
+      if (!button) return;
+
+      if (button.dataset.fold !== undefined) {
+        state.expanded[button.dataset.fold] = true;
+        renderDiff();
+        return;
+      }
+      if (button.dataset.hunk !== undefined) {
+        choose(Number(button.dataset.hunk), button.dataset.choice);
+      }
+    });
+
+    document.addEventListener("keydown", function (event) {
+      if (!event.altKey || event.ctrlKey || event.metaKey) return;
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        goTo(1);
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        goTo(-1);
+      } else if (event.key === "ArrowLeft" && state.current >= 0) {
+        event.preventDefault();
+        choose(state.current, "left");
+      } else if (event.key === "ArrowRight" && state.current >= 0) {
+        event.preventDefault();
+        choose(state.current, "right");
+      }
+    });
+
+    wireDropzone("left");
+    wireDropzone("right");
+
+    window.addEventListener("resize", syncHeaderHeight);
+    narrow.addEventListener("change", applyWidth);
+    if (document.fonts && document.fonts.ready) {
+      // Con la fuente de sistema la cabecera mide otra cosa: hay que volver a
+      // medir cuando llega la definitiva.
+      document.fonts.ready.then(syncHeaderHeight);
+    }
+  }
+
+  wire();
+  syncHeaderHeight();
+  applyWidth();
+  render();
+})();

--- a/diffchecker/js/diff.js
+++ b/diffchecker/js/diff.js
@@ -1,0 +1,599 @@
+/**
+ * Motor de comparacion de textos de /diffchecker/.
+ *
+ * Sin dependencias: ni CDN ni librerias. El algoritmo es el de Myers (1986),
+ * voraz y con traza, sobre las lineas ya normalizadas segun las opciones. Si la
+ * distancia de edicion se dispara, se corta y se reparte el trabajo por anclas
+ * de lineas unicas comunes (la idea del patience diff), que ademas da bloques
+ * mas legibles cuando hay trozos movidos de sitio.
+ *
+ * Lo que este fichero devuelve no es solo lo que se pinta: es tambien lo que el
+ * boton de descarga escribe. Por eso `merge()` trabaja sobre las mismas filas
+ * que se muestran, y build/scripts/check-diff-engine.mjs comprueba que quedarse
+ * con un lado entero devuelve ese lado byte a byte.
+ *
+ * Se expone como `window.DIFF` en el navegador y por `module.exports` cuando se
+ * carga desde Node, para que el verificador pueda probarlo de verdad.
+ *
+ * @author Ismael Sallami Moreno
+ */
+
+(function (root, factory) {
+  "use strict";
+  var api = factory();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (root) root.DIFF = api;
+})(typeof window !== "undefined" ? window : null, function () {
+  "use strict";
+
+  /** Topes duros. Por encima se avisa; nunca se cuelga la pestana en silencio. */
+  var LIMITS = {
+    /** Tamano maximo de cada fichero que se carga. */
+    maxBytes: 5 * 1024 * 1024,
+    /** Lineas maximas sumando los dos lados. */
+    maxLines: 30000,
+    /** Distancia de edicion maxima antes de repartir por anclas. */
+    maxD: 2000,
+    /** Lo mismo, dentro de una linea. */
+    maxWordD: 400,
+    /** Por encima de esto no se busca el cambio palabra a palabra. */
+    maxWordChars: 2000,
+  };
+
+  /* ---------------------------------------------------------------- *
+   * Lineas y claves de comparacion
+   * ---------------------------------------------------------------- */
+
+  /**
+   * Parte en lineas normalizando los finales a LF. Es una decision con
+   * consecuencias: el texto que sale del merge lleva siempre LF.
+   * @param {string} text
+   * @returns {string[]}
+   */
+  function splitLines(text) {
+    return String(text == null ? "" : text)
+      .replace(/\r\n?/g, "\n")
+      .split("\n");
+  }
+
+  /**
+   * Clave con la que se compara una linea. Se compara por la clave y se muestra
+   * (y se descarga) el original, que es lo que hace que «ignorar espacios» no
+   * altere ni una coma del resultado.
+   * @param {string} line
+   * @param {object} options
+   * @returns {string}
+   */
+  function keyOf(line, options) {
+    var key = line;
+    if (options.trimLines) key = key.replace(/^[ \t]+|[ \t]+$/g, "");
+    if (options.ignoreWhitespace) {
+      key = key.replace(/[ \t]+/g, " ").replace(/^ +| +$/g, "");
+    }
+    if (options.ignoreCase) key = key.toLowerCase();
+    return key;
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Myers
+   * ---------------------------------------------------------------- */
+
+  /**
+   * Reconstruye las operaciones recorriendo la traza hacia atras.
+   * @param {Int32Array[]} trace estado antes de cada paso
+   * @param {number} depth pasos gastados
+   * @param {number} n
+   * @param {number} m
+   * @returns {{type: string, a: number, b: number}[]}
+   */
+  function backtrack(trace, depth, n, m) {
+    var ops = [];
+    var x = n;
+    var y = m;
+    var d, before, k, prevK, prevX, prevY;
+
+    for (d = depth; d > 0; d--) {
+      // `before` guarda solo la ventana viva del paso: el indice de k es k+d+1.
+      before = trace[d];
+      k = x - y;
+
+      if (k === -d || (k !== d && before[k + d] < before[k + d + 2])) {
+        prevK = k + 1;
+      } else {
+        prevK = k - 1;
+      }
+
+      prevX = before[prevK + d + 1];
+      prevY = prevX - prevK;
+
+      while (x > prevX && y > prevY) {
+        x--;
+        y--;
+        ops.push({ type: "eq", a: x, b: y });
+      }
+
+      if (x === prevX) {
+        y--;
+        ops.push({ type: "ins", a: -1, b: y });
+      } else {
+        x--;
+        ops.push({ type: "del", a: x, b: -1 });
+      }
+    }
+
+    while (x > 0 && y > 0) {
+      x--;
+      y--;
+      ops.push({ type: "eq", a: x, b: y });
+    }
+
+    ops.reverse();
+    return ops;
+  }
+
+  /**
+   * Myers voraz. Devuelve null si la distancia de edicion pasa del tope, que es
+   * la senal para repartir el trabajo por anclas.
+   * @param {string[]} a
+   * @param {string[]} b
+   * @param {number} maxD
+   * @returns {{type: string, a: number, b: number}[] | null}
+   */
+  function myers(a, b, maxD) {
+    var n = a.length;
+    var m = b.length;
+    if (n === 0 && m === 0) return [];
+
+    var max = Math.min(maxD, n + m);
+    var offset = max + 1;
+    var v = new Int32Array(2 * max + 3);
+    var trace = [];
+    var d, k, x, y;
+
+    for (d = 0; d <= max; d++) {
+      trace.push(v.slice(offset - d - 1, offset + d + 2));
+
+      for (k = -d; k <= d; k += 2) {
+        if (k === -d || (k !== d && v[offset + k - 1] < v[offset + k + 1])) {
+          x = v[offset + k + 1];
+        } else {
+          x = v[offset + k - 1] + 1;
+        }
+        y = x - k;
+
+        while (x < n && y < m && a[x] === b[y]) {
+          x++;
+          y++;
+        }
+        v[offset + k] = x;
+
+        if (x >= n && y >= m) return backtrack(trace, d, n, m);
+      }
+    }
+
+    return null;
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Anclas: lineas que aparecen una sola vez en los dos lados
+   * ---------------------------------------------------------------- */
+
+  /**
+   * Subsecuencia creciente mas larga por la segunda coordenada. Los pares ya
+   * vienen ordenados por la primera.
+   * @param {number[][]} pairs
+   * @returns {number[][]}
+   */
+  function longestIncreasing(pairs) {
+    var tails = [];
+    var links = [];
+    var i, lo, hi, mid;
+
+    for (i = 0; i < pairs.length; i++) {
+      lo = 0;
+      hi = tails.length;
+      while (lo < hi) {
+        mid = (lo + hi) >> 1;
+        if (pairs[tails[mid]][1] < pairs[i][1]) lo = mid + 1;
+        else hi = mid;
+      }
+      links[i] = lo > 0 ? tails[lo - 1] : -1;
+      tails[lo] = i;
+    }
+
+    var out = [];
+    var at = tails.length ? tails[tails.length - 1] : -1;
+    while (at >= 0) {
+      out.push(pairs[at]);
+      at = links[at];
+    }
+    out.reverse();
+    return out;
+  }
+
+  /**
+   * Reparte el tramo por sus anclas y compara cada trozo por separado.
+   * @returns {boolean} false si no hay ninguna ancla que aprovechar
+   */
+  function splitByAnchors(a, b, aOff, bOff, depth, state, out) {
+    var countA = new Map();
+    var countB = new Map();
+    var i, line;
+
+    for (i = 0; i < a.length; i++) {
+      countA.set(a[i], (countA.get(a[i]) || 0) + 1);
+    }
+    for (i = 0; i < b.length; i++) {
+      countB.set(b[i], (countB.get(b[i]) || 0) + 1);
+    }
+
+    var whereB = new Map();
+    for (i = 0; i < b.length; i++) {
+      if (countB.get(b[i]) === 1) whereB.set(b[i], i);
+    }
+
+    var pairs = [];
+    for (i = 0; i < a.length; i++) {
+      line = a[i];
+      if (countA.get(line) !== 1) continue;
+      if (!whereB.has(line)) continue;
+      pairs.push([i, whereB.get(line)]);
+    }
+
+    var anchors = longestIncreasing(pairs);
+    if (anchors.length === 0) return false;
+
+    var ai = 0;
+    var bi = 0;
+    for (i = 0; i < anchors.length; i++) {
+      var pa = anchors[i][0];
+      var pb = anchors[i][1];
+      compareRange(
+        a.slice(ai, pa),
+        b.slice(bi, pb),
+        aOff + ai,
+        bOff + bi,
+        depth + 1,
+        state,
+        out,
+      );
+      out.push({ type: "eq", a: aOff + pa, b: bOff + pb });
+      ai = pa + 1;
+      bi = pb + 1;
+    }
+    compareRange(
+      a.slice(ai),
+      b.slice(bi),
+      aOff + ai,
+      bOff + bi,
+      depth + 1,
+      state,
+      out,
+    );
+    return true;
+  }
+
+  /** Emite el tramo como borrado entero seguido de insertado entero. */
+  function pushPlain(a, b, aOff, bOff, out) {
+    var i;
+    for (i = 0; i < a.length; i++) out.push({ type: "del", a: aOff + i, b: -1 });
+    for (i = 0; i < b.length; i++) out.push({ type: "ins", a: -1, b: bOff + i });
+  }
+
+  /**
+   * Compara un tramo: recorta lo comun por los extremos, prueba Myers y, si no
+   * cabe, reparte por anclas.
+   */
+  function compareRange(a, b, aOff, bOff, depth, state, out) {
+    var i;
+    var start = 0;
+    while (start < a.length && start < b.length && a[start] === b[start]) start++;
+
+    var endA = a.length;
+    var endB = b.length;
+    while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+      endA--;
+      endB--;
+    }
+
+    for (i = 0; i < start; i++) {
+      out.push({ type: "eq", a: aOff + i, b: bOff + i });
+    }
+
+    var midA = a.slice(start, endA);
+    var midB = b.slice(start, endB);
+    var midOffA = aOff + start;
+    var midOffB = bOff + start;
+
+    if (midA.length === 0 || midB.length === 0) {
+      pushPlain(midA, midB, midOffA, midOffB, out);
+    } else {
+      var ops = myers(midA, midB, state.maxD);
+      if (ops) {
+        for (i = 0; i < ops.length; i++) {
+          out.push({
+            type: ops[i].type,
+            a: ops[i].a < 0 ? -1 : ops[i].a + midOffA,
+            b: ops[i].b < 0 ? -1 : ops[i].b + midOffB,
+          });
+        }
+      } else if (
+        depth < 3 &&
+        splitByAnchors(midA, midB, midOffA, midOffB, depth, state, out)
+      ) {
+        // Repartido; cada trozo ya ha escrito lo suyo.
+      } else {
+        state.truncated = true;
+        pushPlain(midA, midB, midOffA, midOffB, out);
+      }
+    }
+
+    for (i = 0; i < a.length - endA; i++) {
+      out.push({ type: "eq", a: aOff + endA + i, b: bOff + endB + i });
+    }
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Diferencias dentro de una linea
+   * ---------------------------------------------------------------- */
+
+  var TOKEN = /\s+|[0-9A-Za-z_À-ɏ]+|[^\s0-9A-Za-z_À-ɏ]/g;
+
+  /** @param {string} text @returns {string[]} */
+  function tokenize(text) {
+    return text.match(TOKEN) || [];
+  }
+
+  /**
+   * Compara dos lineas palabra a palabra. Alimenta el resaltado fino: en
+   * `precio * 1.21` frente a `precio * IVA` marca solo lo que cambia.
+   * @param {string} left
+   * @param {string} right
+   * @returns {{type: string, text: string}[]}
+   */
+  function words(left, right) {
+    if (left === right) {
+      return left === "" ? [] : [{ type: "eq", text: left }];
+    }
+    if (
+      left.length > LIMITS.maxWordChars ||
+      right.length > LIMITS.maxWordChars
+    ) {
+      return whole(left, right);
+    }
+
+    var a = tokenize(left);
+    var b = tokenize(right);
+    var ops = myers(a, b, LIMITS.maxWordD);
+    if (!ops) return whole(left, right);
+
+    var segments = [];
+    for (var i = 0; i < ops.length; i++) {
+      var op = ops[i];
+      var text = op.type === "ins" ? b[op.b] : a[op.a];
+      var last = segments[segments.length - 1];
+      if (last && last.type === op.type) last.text += text;
+      else segments.push({ type: op.type, text: text });
+    }
+    return segments;
+  }
+
+  /** Sin nada aprovechable en comun: fuera lo viejo, dentro lo nuevo. */
+  function whole(left, right) {
+    var out = [];
+    if (left !== "") out.push({ type: "del", text: left });
+    if (right !== "") out.push({ type: "ins", text: right });
+    return out;
+  }
+
+  /**
+   * Devuelve el detalle por palabras solo si las dos lineas se parecen. Entre
+   * dos lineas sin nada que ver, el resaltado fino es ruido: mejor marcarlas
+   * enteras.
+   * @returns {{type: string, text: string}[] | null}
+   */
+  function wordsIfAlike(left, right) {
+    var segments = words(left, right);
+    var shared = 0;
+    for (var i = 0; i < segments.length; i++) {
+      if (segments[i].type === "eq") shared += segments[i].text.trim().length;
+    }
+    var longest = Math.max(left.trim().length, right.trim().length);
+    if (longest === 0) return null;
+    return shared * 4 >= longest ? segments : null;
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Filas y bloques
+   * ---------------------------------------------------------------- */
+
+  /** Una celda vacia: ese lado no tiene linea en esa fila. */
+  function empty() {
+    return { n: null, text: null };
+  }
+
+  /**
+   * Convierte la lista de operaciones en filas alineadas y en bloques de
+   * cambio, que es lo que la interfaz pinta y lo que el merge recorre.
+   */
+  function buildRows(ops, leftLines, rightLines) {
+    var rows = [];
+    var hunks = [];
+    var i = 0;
+
+    while (i < ops.length) {
+      if (ops[i].type === "eq") {
+        var leftText = leftLines[ops[i].a];
+        var rightText = rightLines[ops[i].b];
+        rows.push({
+          type: "eq",
+          left: { n: ops[i].a + 1, text: leftText },
+          right: { n: ops[i].b + 1, text: rightText },
+          hunk: null,
+          words: null,
+          // Iguales para la comparacion pero distintas de verdad: solo pasa con
+          // las opciones de ignorar. No hay bloque que elegir, asi que el merge
+          // se queda con la izquierda; la interfaz lo senala para que no sea
+          // una sorpresa al descargar.
+          soft: leftText !== rightText,
+        });
+        i++;
+        continue;
+      }
+
+      // Myers puede intercalar borrados e inserciones dentro de un mismo
+      // cambio. Se juntan todos los del tramo y se emparejan por posicion, que
+      // es lo que da la vista lado a lado.
+      var dels = [];
+      var ins = [];
+      while (i < ops.length && ops[i].type !== "eq") {
+        if (ops[i].type === "del") dels.push(ops[i].a);
+        else ins.push(ops[i].b);
+        i++;
+      }
+
+      var kind = dels.length && ins.length ? "change" : ins.length ? "add" : "remove";
+      var hunk = {
+        id: hunks.length,
+        kind: kind,
+        left: dels.map(function (at) {
+          return leftLines[at];
+        }),
+        right: ins.map(function (at) {
+          return rightLines[at];
+        }),
+        leftStart: dels.length ? dels[0] + 1 : null,
+        rightStart: ins.length ? ins[0] + 1 : null,
+        rowStart: rows.length,
+        rowEnd: rows.length,
+        choice: "left",
+      };
+
+      var height = Math.max(dels.length, ins.length);
+      for (var j = 0; j < height; j++) {
+        var leftAt = j < dels.length ? dels[j] : -1;
+        var rightAt = j < ins.length ? ins[j] : -1;
+        var pair =
+          leftAt >= 0 && rightAt >= 0 && kind === "change"
+            ? wordsIfAlike(leftLines[leftAt], rightLines[rightAt])
+            : null;
+
+        rows.push({
+          type: kind,
+          left:
+            leftAt >= 0 ? { n: leftAt + 1, text: leftLines[leftAt] } : empty(),
+          right:
+            rightAt >= 0 ? { n: rightAt + 1, text: rightLines[rightAt] } : empty(),
+          hunk: hunk.id,
+          words: pair,
+          soft: false,
+        });
+      }
+
+      hunk.rowEnd = rows.length - 1;
+      hunks.push(hunk);
+    }
+
+    return { rows: rows, hunks: hunks };
+  }
+
+  /* ---------------------------------------------------------------- *
+   * API
+   * ---------------------------------------------------------------- */
+
+  /**
+   * Compara dos textos.
+   * @param {string} leftText
+   * @param {string} rightText
+   * @param {{ignoreWhitespace?: boolean, ignoreCase?: boolean,
+   *          trimLines?: boolean}} [options]
+   * @returns {object}
+   */
+  function compare(leftText, rightText, options) {
+    var opts = options || {};
+    var leftLines = splitLines(leftText);
+    var rightLines = splitLines(rightText);
+
+    if (leftLines.length + rightLines.length > LIMITS.maxLines) {
+      throw new RangeError(
+        "Demasiadas lineas: el limite son " + LIMITS.maxLines + " entre los dos textos.",
+      );
+    }
+
+    var leftKeys = leftLines.map(function (line) {
+      return keyOf(line, opts);
+    });
+    var rightKeys = rightLines.map(function (line) {
+      return keyOf(line, opts);
+    });
+
+    var state = { maxD: LIMITS.maxD, truncated: false };
+    var ops = [];
+    compareRange(leftKeys, rightKeys, 0, 0, 0, state, ops);
+
+    var built = buildRows(ops, leftLines, rightLines);
+    var stats = { added: 0, removed: 0, changed: 0, equal: 0 };
+
+    for (var i = 0; i < built.hunks.length; i++) {
+      var hunk = built.hunks[i];
+      if (hunk.kind === "add") stats.added += hunk.right.length;
+      else if (hunk.kind === "remove") stats.removed += hunk.left.length;
+      else stats.changed += Math.max(hunk.left.length, hunk.right.length);
+    }
+    for (i = 0; i < built.rows.length; i++) {
+      if (built.rows[i].hunk === null) stats.equal++;
+    }
+
+    return {
+      rows: built.rows,
+      hunks: built.hunks,
+      stats: stats,
+      truncated: state.truncated,
+      leftLines: leftLines.length,
+      rightLines: rightLines.length,
+    };
+  }
+
+  /**
+   * Construye el texto resultante segun la eleccion de cada bloque. Las filas
+   * iguales van tal cual y cada bloque aporta el lado elegido.
+   * @param {object} result lo que devuelve compare()
+   * @returns {string}
+   */
+  function merge(result) {
+    var out = [];
+    var done = Object.create(null);
+    var i, j, row, hunk;
+
+    for (i = 0; i < result.rows.length; i++) {
+      row = result.rows[i];
+
+      if (row.hunk === null) {
+        out.push(row.left.text);
+        continue;
+      }
+      if (done[row.hunk]) continue;
+      done[row.hunk] = true;
+
+      hunk = result.hunks[row.hunk];
+      if (hunk.choice === "right") {
+        for (j = 0; j < hunk.right.length; j++) out.push(hunk.right[j]);
+      } else if (hunk.choice === "both") {
+        for (j = 0; j < hunk.left.length; j++) out.push(hunk.left[j]);
+        for (j = 0; j < hunk.right.length; j++) out.push(hunk.right[j]);
+      } else {
+        for (j = 0; j < hunk.left.length; j++) out.push(hunk.left[j]);
+      }
+    }
+
+    return out.join("\n");
+  }
+
+  return {
+    LIMITS: LIMITS,
+    compare: compare,
+    merge: merge,
+    words: words,
+    splitLines: splitLines,
+  };
+});

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
           <div class="hero-stat-label">Recursos</div>
         </div>
         <div class="hero-stat">
-          <div class="hero-stat-num">4</div>
+          <div class="hero-stat-num">5</div>
           <div class="hero-stat-label">Herramientas</div>
         </div>
         </div>
@@ -154,7 +154,7 @@
           <span>
             <span class="tile-title">Herramientas</span>
             <span class="tile-blurb">Pequeñas apps que funcionan al 100% en tu navegador: sin instalar nada y sin que tus archivos salgan de tu equipo.</span>
-            <span class="tile-summary">2 herramientas · sin servidor · código abierto</span>
+            <span class="tile-summary">3 herramientas · sin servidor · código abierto</span>
           </span>
           <span class="tile-arrow" aria-hidden="true">→</span>
         </a>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "build": "node build/render.mjs",
     "serve": "node build/serve.mjs",
     "dev": "npm run build && npm run serve",
-    "check": "node build/render.mjs --check && node build/scripts/check-links.mjs"
+    "check": "node build/render.mjs --check && node build/scripts/check-links.mjs && node build/scripts/check-diff-engine.mjs"
   }
 }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -21,6 +21,11 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://elblogdeismael.github.io/diffchecker/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://elblogdeismael.github.io/doble-grado/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/tools/index.html
+++ b/tools/index.html
@@ -84,7 +84,7 @@
         Herra<span class="ttl-stroke">mientas</span>
       </h1>
       <p class="page-sub">
-        <span>2 herramientas · sin servidor · código abierto</span>
+        <span>3 herramientas · sin servidor · código abierto</span>
         <span>Universidad de Granada</span>
       </p>
 
@@ -120,6 +120,14 @@
           <span>
             <span class="tile-title">pdf2md · código fuente</span>
 
+          </span>
+          <span class="tile-arrow" aria-hidden="true">→</span>
+        </a>
+        <a class="tile reveal" style="--i:4" href="/diffchecker/">
+          <span class="tile-num">05</span>
+          <span>
+            <span class="tile-title">diffchecker</span>
+            <span class="tile-blurb">comparar dos textos y mezclarlos</span>
           </span>
           <span class="tile-arrow" aria-hidden="true">→</span>
         </a>


### PR DESCRIPTION
Tercera herramienta de navegador del sitio, en `/diffchecker/`, junto a
`md2html` y `pdf2md`. Resuelve algo que aparece constantemente al mantener
apuntes: tener dos versiones del mismo texto, no saber en qué se diferencian, y
querer una tercera que se quede con lo bueno de cada una.

La referencia es [diffchecker.com](https://www.diffchecker.com/), de donde sale
la vista lado a lado con resaltado por palabras. Lo que se añade por encima es el
**mezclado bloque a bloque**: `◀` se queda con el original, `▶` con el
modificado, `◀▶` con los dos, y el resultado se copia o se descarga.

## Qué entra

| | |
| --- | --- |
| `diffchecker/js/diff.js` | El motor. Myers con traza, sin dependencias |
| `diffchecker/index.html`, `js/app.js` | Tres vistas: editar, diferencias y resultado |
| `build/scripts/check-diff-engine.mjs` | El verificador, encadenado a `npm run check` |
| `assets/css/brutal/tool.css` | Sección nueva en la capa fuente |
| `content/sections/tools/section.mjs` | Una entrada, y el resumen a «3 herramientas» |

Entradas: texto pegado y ficheros de texto arrastrados. Sin PDF ni imágenes.

## El motor no viene de una CDN

Está escrito de cero: Myers voraz con traza sobre las líneas ya normalizadas
según las opciones, recortando prefijo y sufijo comunes. Cuando la distancia de
edición pasa del tope, en vez de rendirse reparte el trabajo por **anclas de
líneas únicas comunes** —la idea del patience diff— y compara cada trozo por
separado. Solo si tampoco hay anclas se marca el tramo entero como reemplazo, y
la interfaz lo dice.

Medido sobre documentos del propio repositorio:

| | |
| --- | ---: |
| `MAC/src/03_relaciones.md` (1.169 líneas) con 60 líneas retocadas | **4 ms** |
| Ese documento contra `AEF/src/02_indicadores.md`, sin nada en común | **40 ms** |
| 400 líneas en la vista de diferencias | **28 filas** en el DOM, plegando los tramos iguales |

El fichero se exporta por `module.exports` cuando se carga desde Node. Es
deliberado: `md2html/js/converter.js` no se puede probar precisamente porque no
lo hace.

## Cómo está verificado

El motor decide lo que se pinta **y lo que el botón de descarga escribe**, así
que un fallo aquí es del peor tipo: la pantalla parece correcta y el fichero
descargado no. `check-diff-engine.mjs` compara **cadenas completas, nunca
recuentos**:

1. Todas las elecciones a la izquierda → el resultado es el texto izquierdo byte
   a byte. Ídem con la derecha.
2. Leer un lado de las filas en orden reconstruye ese lado.
3. La numeración de línea es correlativa, sin huecos ni repeticiones.
4. No hay cambios si y solo si los textos son iguales.
5. Los bloques cubren tramos de filas disjuntos y ordenados.

16 casos fijos —CRLF frente a LF, sin salto final, inserción y borrado puros,
texto vacío, líneas repetidas, bloque movido, línea de 20.000 caracteres— más
200 pares aleatorios con semilla, reproducibles desde la semilla que imprime el
informe. Pasa también con **400 pares en cinco semillas distintas**, y forzando
el tope de Myers a 4 para que se ejecutara la vía de anclas: **0 fallos en 300
pares**.

En el navegador se comprobó la cadena completa: la mezcla real bloque a bloque
contrastando el texto resultante contra el esperado, la carga de ficheros con
acentos, el rechazo de un binario sin pisar lo ya cargado, los atajos de teclado,
intercambiar y limpiar, los dos temas y tres anchos. La pestaña de red confirma
que no se pide **ninguna** librería externa: solo las fuentes y Analytics, igual
que las otras dos herramientas.

## Cuatro cosas que se corrigieron al mirarlas

- **El lado derecho nacía atenuado**, porque `◀` era el valor por defecto.
  Atenuar tiene que significar «he decidido», no «este es el valor inicial»: con
  media pantalla apagada, comparar cuesta más. Ahora solo se atenúa lo resuelto.
- **A 390px la vista lado a lado era inservible**, con cada línea partida en
  columnas de ocho letras. Por debajo de 900px se fuerza la unificada, se
  desactiva el conmutador y la barra deja de ser pegajosa.
- **Los bloques que solo añaden se quedaban sin botones** en la vista unificada,
  porque no tienen línea izquierda donde ponerlos.
- **La cabecera mide 62px y yo había asumido 53** al fijar la barra pegajosa. En
  vez de corregir la constante, ahora se mide: es lo único que no envejece
  cuando cambian la tipografía o el ancho.

## Decisiones que conviene revisar

- **Al ignorar espacios o mayúsculas**, dos líneas que solo se distinguen en eso
  no forman bloque, así que el resultado conserva la del original. Para que no
  sea una sorpresa al descargar, esas líneas salen con subrayado de puntos.
- **Los finales de línea se normalizan a LF.** Está dicho en la página.
- **Una sola entrada en la sección**, sin la línea «· código fuente» que sí
  tienen las otras dos: no hay repositorio propio todavía, y enlazar una carpeta
  de este repositorio en GitHub es justo lo que la fase 5 dejó a cero.
- **El nombre roza una marca ajena.** Con la URL solo en el blog no pasa nada; si
  algún día la herramienta se publica como repositorio propio, ese nombre se va a
  encontrar con diffchecker.com.

## Comprobaciones

```
npm run check
  Site is up to date (19 files).
  224 links: 181 local, 43 external (not requested).
  All local links resolve.
  Diff engine: 16 fixed cases, 200 random pairs, plus options and word level checks.
  Every property holds.
```

Los tres commits pasan `npm run check` **uno a uno**, no solo al final. Nada que
tocar en `.github/`: `deploy.yml` copia todo el repositorio salvo cinco rutas, así
que una carpeta nueva en la raíz se publica por existir, y la poda solo alcanza a
ficheros de 1 MiB o más.
