### PR TITLE
cerrando la reorganización y anotando lo que queda

### DIFF
--- a/docs/reorganizacion/README.md
+++ b/docs/reorganizacion/README.md
@@ -4,8 +4,10 @@ Plan de trabajo para separar el sitio web, los apuntes, el material ajeno y el c
 prácticas, y para dejar los repositorios de `Ismael-Sallami` en condiciones de servir como
 portfolio.
 
-> **Estado: seis fases cerradas, queda la 6.** Las fases 4 y 5 se cerraron del todo el
-> 2026-08-02, con los puntos que habían dejado pendientes resueltos.
+> **Estado: las siete fases están cerradas.** La última fue la 6, el 2026-08-16, con
+> las 26 asignaturas de primero y segundo escritas. Lo que queda de contenido no es
+> una fase y está al final de este documento, en
+> [Después de la reorganización](#después-de-la-reorganización).
 >
 > Seguimiento en GitHub: milestone [Reorganización 2026](https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io/milestone/1)
 > e issue paraguas [#10](https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io/issues/10).
@@ -121,5 +123,42 @@ No está en el CI: compilar cien documentos LaTeX en cada push no cabe en un run
 
 Al cerrar una fase: marcar su checklist, cerrar su issue y actualizar la columna «Estado»
 de la tabla de arriba.
+
+**Las casillas `- [ ]` que quedan en los documentos de fase no son trabajo pendiente.**
+Son los pasos del procedimiento de fases ya cerradas, y se conservan porque describen
+cómo se hizo. El estado real de cada fase está en la tabla de arriba, no en sus
+casillas.
+
+## Después de la reorganización
+
+Terminada la fase 6, el sitio publica material propio de las 26 asignaturas de primero
+y segundo, de las 13 de tercero y de las 11 de cuarto. **Lo que sigue faltando es
+contenido, no estructura**, así que no hay fase nueva: se escribe asignatura a
+asignatura con el patrón de la fase 6 —`Subjects/_template`, un capítulo por tema de la
+guía docente, bibliografía de la guía citada donde el texto se apoya en ella— con un
+commit y una ficha por asignatura.
+
+Comprobado ficha a ficha el 2026-08-16:
+
+| Asignatura | Lo que hay | Lo que falta |
+| --- | --- | --- |
+| **OE** · Organización de Empresas (4º) | el informe de CaixaBank y tres tests | el temario entero: `Subjects/Fourth/OE/` solo tiene `practicas/` y `test/` |
+| **MH** · Metaheurísticas (4º) | nada propio en la ficha; el código está en el repositorio `metaheuristics` | el temario, y enlazar ese repositorio desde la ficha |
+| **ECO** · Econometría (3º) | prácticas y formulario | el temario |
+| **FR** · Fundamentos de Redes (3º) | resúmenes de los temas 1 a 5, preguntas resueltas y tres tests | un temario de teoría |
+| **CF1** · Contabilidad Financiera I (3º) | teoría de los temas 1 a 3, resúmenes de los seis, ejercicios de los temas 2 a 6 y nueve tests | la teoría de los temas 4, 5 y 6 |
+
+Dos avisos, que salen de lo aprendido en las fases 5 y 6:
+
+- **Los `Teoria.tex` de FR y de ECO no son borradores.** Son el cascarón que quedó al
+  retirar el material del profesorado que envolvían: el de ECO tiene una sola sección,
+  «Referencias», y el de FR dos, «Teoria» y «Fuente». Un documento que se queda en
+  portada e índice se borra; antes de reutilizarlo, mirar su `.fls` (`grep INPUT`)
+  para ver qué incluía de verdad.
+- **CF1 es media asignatura, no una entera.** Los temas 1 a 3 ya están publicados y
+  hay que continuar su formato.
+
+**Quinto queda fuera**: sus siete fichas están vacías a propósito y `Subjects/Fifth/`
+no tiene ni un fichero, porque es un curso que todavía no se ha cursado.
 
 @author Ismael Sallami Moreno

--- a/docs/reorganizacion/fase-2-contenido.md
+++ b/docs/reorganizacion/fase-2-contenido.md
@@ -5,13 +5,22 @@ copiarlo) · **Rama:** `reorg/fase-2-contenido`
 
 ---
 
-## Estado: primera pasada hecha, la destructiva pendiente
+## Estado: cerrada
 
-La pasada del 2026-07-31 hizo **la parte C, la parte D de cuarto y las prácticas de
-grupo**. La parte A y la B —mover el material ajeno— siguen pendientes, a propósito:
-**`git rm` no baja ni un byte del `size-pack`**, porque el peso vive en el historial y
-solo la [fase 3](fase-3-historial.md) lo reescribe. Lo que sí queda es el inventario
-medido en `.inventario-material-ajeno.txt`: **217 ficheros, 972 MB**.
+**La pasada del 2026-07-31** hizo la parte C, la parte D de cuarto y las prácticas de
+grupo. **La parte A y la B —mover el material ajeno— se hicieron después**, y no como
+las describía este documento: el material fue a copia local en `~/backups/`, y quien
+bajó el peso de verdad fue la [fase 3](fase-3-historial.md) reescribiendo el historial,
+porque **`git rm` no baja ni un byte del `size-pack`**. El inventario que se usó está
+en `.inventario-material-ajeno.txt`: **217 ficheros, 972 MB**.
+
+Las retiradas siguieron hasta el 2026-08-09, ya desde la
+[fase 6](fase-6-contenido-pendiente.md), al descubrirse que la clasificación por
+metadatos había dejado 39 ficheros del profesorado en la clase «propio».
+
+**Las casillas sin marcar de más abajo son el procedimiento que este documento
+proponía, no trabajo pendiente.** Se conservan porque describen el plan original y
+en qué se equivocaba.
 
 Decisiones tomadas en esa pasada:
 

--- a/docs/reorganizacion/fase-6-contenido-pendiente.md
+++ b/docs/reorganizacion/fase-6-contenido-pendiente.md
@@ -1,7 +1,13 @@
 # Fase 6 — Contenido pendiente
 
-**Duración:** continua, sin fecha de cierre · **Destructiva:** no ·
-**Rama:** una por asignatura, `contenido/<codigo>`
+**Estado:** **cerrada el 2026-08-16**, con **26 de 26** asignaturas de primero y
+segundo escritas · **Destructiva:** no ·
+**Rama:** una por tanda, `contenido/<lo que cubra>`
+
+Lo que quedó fuera de esta fase y sigue faltando —OE y MH de cuarto, ECO, FR y la
+mitad de CF1 de tercero— está en
+[Después de la reorganización](README.md#después-de-la-reorganización). No es una fase
+nueva: se escribe con el mismo procedimiento que hay aquí.
 
 ---
 


### PR DESCRIPTION
Deja escrito el estado real ahora que la fase 6 está cerrada, para que se pueda retomar sin releer el historial.

- **README de la reorganización**: las siete fases cerradas, y una sección **Después de la reorganización** con las cinco asignaturas de tercero y cuarto que siguen sin temario —OE, MH, ECO, FR y los temas 4 a 6 de CF1—, con lo que hay hoy en cada una y lo que falta. Comprobado ficha a ficha. Quinto queda fuera: sus siete fichas están vacías a propósito.
- **Aviso sobre las casillas `- [ ]`** que quedan en los documentos de fase: son el procedimiento de fases ya cerradas, no trabajo pendiente. Eran 62 y confundían.
- **Cabecera de la fase 2**, que seguía diciendo «la destructiva pendiente» cuando esa parte la hizo la fase 3 reescribiendo el historial.
- **Cabecera de la fase 6**, que seguía diciendo «continua, sin fecha de cierre».

Dos avisos que se anotan porque ya han costado tiempo: los `Teoria.tex` de FR y de ECO no son borradores sino el cascarón que quedó al retirar el material del profesorado, y CF1 es media asignatura, con los temas 1 a 3 ya publicados.

Solo documentación. `npm run check`: 435 enlaces, todos los locales resuelven.