### PR TITLE
Publicar diffchecker, dar una tarjeta a cada herramienta y repasar el README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+# Con este fichero GitHub pinta un boton «Cite this repository» en la portada
+# del repositorio. Se actualiza `date-released` cuando cambie algo sustancial.
+cff-version: 1.2.0
+title: "El blog de Ismael Sallami: apuntes del Doble Grado en Ingeniería Informática y ADE"
+message: "Si usas estos apuntes, cítalos así."
+type: dataset
+authors:
+  - family-names: "Sallami Moreno"
+    given-names: "Ismael"
+    affiliation: "Universidad de Granada"
+repository-code: "https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+url: "https://elblogdeismael.github.io"
+abstract: >-
+  Apuntes, prácticas, exámenes resueltos y herramientas del Doble Grado en
+  Ingeniería Informática y Administración y Dirección de Empresas de la
+  Universidad de Granada. El temario de cada asignatura sigue su guía docente
+  oficial y cita la bibliografía de esa guía.
+keywords:
+  - apuntes
+  - universidad de granada
+  - ingeniería informática
+  - administración y dirección de empresas
+license: MIT
+date-released: "2026-08-18"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # El blog de Ismael Sallami
 
+[![Deploy to GitHub Pages](https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io/actions/workflows/deploy.yml)
+
 Apuntes, prácticas y material del Doble Grado en Ingeniería Informática y ADE
 de la Universidad de Granada. Publicado en
 [elblogdeismael.github.io](https://elblogdeismael.github.io).
+
+**Es un archivo personal, no un proyecto abierto.** No se buscan colaboradores y
+no hay guía de contribución: lo que se publica aquí lo escribe una persona. Si
+encuentras una errata o un enlace movido, hay dos formularios de issue; si lo que
+encuentras es material que no debería estar publicado, mira
+[«Avisos»](#avisos) antes de abrir nada.
 
 ## Cómo funciona
 
@@ -41,6 +49,12 @@ node build/scripts/check-latex-builds.mjs --only FBD   # solo lo tocado
 
 Necesita Node 20 o superior. No hay que instalar nada.
 
+**Al tocar un `.tex`, el barrido no basta: hay que abrir el PDF y mirarlo.** Una
+figura mal dibujada compila sin una sola queja —leyendas encima de las barras,
+rótulos que se salen de su caja, un eje pisado—, y eso solo se ve renderizando la
+página con `pdftoppm -f N -l N -r 100 -png`. Lo mismo con las cuentas de un
+ejemplo numérico: un documento compila igual de bien con las sumas mal.
+
 **El HTML generado se versiona.** Después de tocar `content/` hay que ejecutar
 `npm run build` o el sitio no cambia, y el CI falla con `npm run check`.
 
@@ -56,6 +70,35 @@ buena: eso se barre a mano con `curl`.
 
 **Una asignatura** — añade un objeto `{ code, name, blocks }` al semestre que
 toque, en el mismo fichero.
+
+**La guía docente de una asignatura**, que es el primer recurso de toda ficha:
+
+```
+https://grados.ugr.es/informatica-ade/docencia/plan-estudios/<slug>/guia-docente
+```
+
+El *slug* sale del índice del plan de estudios. Dos avisos que han costado tiempo
+dos veces:
+
+- **Las optativas de Computación y Sistemas Inteligentes cuelgan del grado de
+  Informática**, no del doble grado: es el caso de MH y de AA, con
+  `grados.ugr.es/informatica/…` y otro slug.
+- **Cuando esa página da 404, la guía firmada sí existe** en
+  `guias-firmadas/<curso>/<codigo>.pdf`. El código **no aparece en ninguna
+  página**: se encuentra barriendo el rango y leyendo la primera página del PDF
+  con `pdftotext`. Así salieron FBD (`216113D`) y MAC (`296113D`).
+
+Si de verdad no hay guía, el modelo tiene `note: true` para eso. **Nunca
+`href: "#"`.**
+
+**Un apunte que se lea en el navegador** — enlázalo con `/viewer/?file=<ruta>`,
+nunca con una ruta relativa al `.md`. Así se sirven 245 recursos: el visor
+descarga el markdown y lo renderiza en la página, con las figuras de tikz
+compiladas al vuelo.
+
+**Un test autocorregible** — `test/*.md` es la fuente y `test/*.html` el
+artefacto que genera md2html. Los dos se versionan, porque Pages sirve el HTML
+directamente, pero **solo se edita el `.md`**.
 
 **Los apuntes de una asignatura**, que es escribir un PDF nuevo:
 
@@ -143,7 +186,7 @@ Las que se escriben a mano:
 | `Subjects/` | El material en sí: PDF, LaTeX, Markdown, tests y prácticas |
 | `md2html/`, `pdf2md/`, `diffchecker/`, `viewer/` | Cuatro apps que funcionan enteras en el navegador. Las tres primeras se ofrecen en Herramientas; al visor se entra desde los recursos `.md` de las fichas |
 | `extraFiles/preambulos_oficiales/` | La plantilla LaTeX compartida. **Está viva**: ver abajo |
-| `docs/reorganizacion/` | El plan de la reorganización, por fases. Cerrado el 16 de agosto de 2026 |
+| `docs/` | La documentación del propio repositorio. Hoy solo tiene `reorganizacion/`: el plan por fases, cerrado el 16 de agosto de 2026, con las reglas y las decisiones que siguen valiendo |
 
 Las que **genera el build** y no se editan a mano:
 
@@ -176,6 +219,18 @@ Si encuentras una clave, un dato personal o material con derechos de autor
 publicado aquí, **no se avisa en una issue pública**: cómo hacerlo está en
 [`.github/SECURITY.md`](.github/SECURITY.md). Para una errata o un enlace
 movido hay dos formularios de issue.
+
+## Licencia
+
+El **código** —el generador, las plantillas, el sistema de diseño y las tres apps
+del navegador— va bajo MIT, en [`LICENSE`](LICENSE).
+
+Los **apuntes** son material propio, escritos siguiendo la guía docente de cada
+asignatura y con su bibliografía citada donde el texto se apoya en ella. Si los
+reutilizas, cita de dónde salen. Y lo que no está aquí y no va a estar: material
+del profesorado, guiones, transparencias y capítulos de manual, **tampoco
+incrustados como imagen dentro de un documento propio**, que es por donde se
+coló tres veces.
 
 ## Contacto
 

--- a/assets/css/brutal.css
+++ b/assets/css/brutal.css
@@ -830,6 +830,64 @@ a {
   color: var(--accent);
 }
 
+/* ---- Tarjeta con dos destinos ------------------------------------------
+   Las herramientas abren la app y ademas ofrecen su repositorio. Dos enlaces
+   en la misma tarjeta no pueden anidarse, asi que la tarjeta es un <div>: el
+   principal se estira con un ::after y el cuadrado queda por encima. */
+
+.tile-dual {
+  grid-template-columns: 1fr auto auto;
+}
+
+.tile-main {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: var(--gap);
+  text-decoration: none;
+  color: inherit;
+}
+
+/* Esto es lo que mantiene clicable toda la tarjeta con un solo enlace. */
+.tile-main::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
+/* El cuadrado del codigo. Va por encima del ::after de arriba, que si no se
+   lo tragaria. */
+.tile-src {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  background: var(--accent-2);
+  color: var(--accent-ink);
+  border: var(--line) solid var(--ink);
+  box-shadow: 4px 4px 0 var(--shadow-col);
+  transition:
+    transform var(--base) var(--ease),
+    box-shadow var(--base) var(--ease);
+}
+.tile-src:hover,
+.tile-src:focus-visible {
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--shadow-col);
+}
+
+/* El foco del enlace principal tiene que verse en la tarjeta entera, no en un
+   rectangulo de altura cero. */
+.tile-main:focus-visible {
+  outline: none;
+}
+.tile:has(.tile-main:focus-visible) {
+  outline: var(--line) solid var(--accent);
+  outline-offset: 4px;
+}
+
 /* ===================== SLAB ===================== */
 
 /* Generic bordered block. The base for anything that is not a card. */

--- a/assets/css/brutal/components.css
+++ b/assets/css/brutal/components.css
@@ -283,6 +283,64 @@
   color: var(--accent);
 }
 
+/* ---- Tarjeta con dos destinos ------------------------------------------
+   Las herramientas abren la app y ademas ofrecen su repositorio. Dos enlaces
+   en la misma tarjeta no pueden anidarse, asi que la tarjeta es un <div>: el
+   principal se estira con un ::after y el cuadrado queda por encima. */
+
+.tile-dual {
+  grid-template-columns: 1fr auto auto;
+}
+
+.tile-main {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: var(--gap);
+  text-decoration: none;
+  color: inherit;
+}
+
+/* Esto es lo que mantiene clicable toda la tarjeta con un solo enlace. */
+.tile-main::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
+/* El cuadrado del codigo. Va por encima del ::after de arriba, que si no se
+   lo tragaria. */
+.tile-src {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  background: var(--accent-2);
+  color: var(--accent-ink);
+  border: var(--line) solid var(--ink);
+  box-shadow: 4px 4px 0 var(--shadow-col);
+  transition:
+    transform var(--base) var(--ease),
+    box-shadow var(--base) var(--ease);
+}
+.tile-src:hover,
+.tile-src:focus-visible {
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--shadow-col);
+}
+
+/* El foco del enlace principal tiene que verse en la tarjeta entera, no en un
+   rectangulo de altura cero. */
+.tile-main:focus-visible {
+  outline: none;
+}
+.tile:has(.tile-main:focus-visible) {
+  outline: var(--line) solid var(--accent);
+  outline-offset: 4px;
+}
+
 /* ===================== SLAB ===================== */
 
 /* Generic bordered block. The base for anything that is not a card. */

--- a/build/templates/section.mjs
+++ b/build/templates/section.mjs
@@ -43,6 +43,12 @@ function pageTile(section, page, index) {
         </a>`;
 }
 
+/*
+ * La marca de GitHub, en linea. Es el mismo criterio que los iconos del
+ * conmutador de tema: SVG propio en el HTML, sin CDN ni fuente de iconos.
+ */
+const GITHUB_MARK = `<svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>`;
+
 /**
  * @param {import("../../content/types.d.ts").Resource} link
  * @param {number} index
@@ -51,15 +57,32 @@ function pageTile(section, page, index) {
 function linkTile(link, index) {
   const external = isExternal(link.href) ? ' target="_blank" rel="noopener"' : "";
   const [name, blurb] = link.name.split(" — ");
-
-  return `        <a class="tile reveal" style="--i:${index}" href="${escape(link.href)}"${external}>
-          <span class="tile-num">${String(index + 1).padStart(2, "0")}</span>
+  const num = String(index + 1).padStart(2, "0");
+  const body = `          <span class="tile-num">${num}</span>
           <span>
             <span class="tile-title">${escape(name)}</span>
 ${blurb ? `            <span class="tile-blurb">${escape(blurb)}</span>` : ""}
-          </span>
+          </span>`;
+
+  // Sin repositorio la tarjeta es un solo <a>, como las de los cursos.
+  if (!link.repo) {
+    return `        <a class="tile reveal" style="--i:${index}" href="${escape(link.href)}"${external}>
+${body}
           <span class="tile-arrow" aria-hidden="true">→</span>
         </a>`;
+  }
+
+  // Con repositorio hacen falta dos enlaces, y uno dentro de otro no es HTML
+  // valido. Asi que la tarjeta pasa a ser un <div>: el enlace principal se
+  // estira sobre ella con un ::after, y el cuadrado queda por encima.
+  return `        <div class="tile tile-dual reveal" style="--i:${index}">
+          <a class="tile-main" href="${escape(link.href)}"${external}>
+${body}
+          </a>
+          <a class="tile-src" href="${escape(link.repo)}" target="_blank" rel="noopener"
+             aria-label="Código de ${escape(name)} en GitHub">${GITHUB_MARK}</a>
+          <span class="tile-arrow" aria-hidden="true">→</span>
+        </div>`;
 }
 
 /**

--- a/content/sections/tools/section.mjs
+++ b/content/sections/tools/section.mjs
@@ -25,26 +25,19 @@ export default {
       name: "md2html — apuntes Markdown a test HTML autocorregible",
       href: "/md2html/",
       kind: "WEB",
-    },
-    {
-      name: "md2html · código fuente",
-      href: "https://github.com/Ismael-Sallami/md2html-testGenerator",
-      kind: "WEB",
+      repo: "https://github.com/Ismael-Sallami/md2html-testGenerator",
     },
     {
       name: "pdf2md — PDF, Word y Excel a Markdown",
       href: "/pdf2md/",
       kind: "WEB",
-    },
-    {
-      name: "pdf2md · código fuente",
-      href: "https://github.com/Ismael-Sallami/pdf-to-md",
-      kind: "WEB",
+      repo: "https://github.com/Ismael-Sallami/pdf-to-md",
     },
     {
       name: "diffchecker — comparar dos textos y mezclarlos",
       href: "/diffchecker/",
       kind: "WEB",
+      repo: "https://github.com/Ismael-Sallami/diffchecker",
     },
   ],
 };

--- a/content/types.d.ts
+++ b/content/types.d.ts
@@ -49,6 +49,12 @@ export interface Resource {
    * and for material that exists but is not published here.
    */
   note?: boolean;
+  /**
+   * Repository that holds the source, for the browser tools. It is painted as
+   * a small square inside the tile, next to the arrow, and is a link of its
+   * own: the rest of the tile opens `href`.
+   */
+  repo?: string;
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
           <div class="hero-stat-label">Recursos</div>
         </div>
         <div class="hero-stat">
-          <div class="hero-stat-num">5</div>
+          <div class="hero-stat-num">3</div>
           <div class="hero-stat-label">Herramientas</div>
         </div>
         </div>

--- a/tools/index.html
+++ b/tools/index.html
@@ -91,46 +91,42 @@
       <p class="section-intro">Pequeñas apps que funcionan al 100% en tu navegador: sin instalar nada y sin que tus archivos salgan de tu equipo.</p>
 
       <div class="tile-list">
-        <a class="tile reveal" style="--i:0" href="/md2html/">
+        <div class="tile tile-dual reveal" style="--i:0">
+          <a class="tile-main" href="/md2html/">
           <span class="tile-num">01</span>
           <span>
             <span class="tile-title">md2html</span>
             <span class="tile-blurb">apuntes Markdown a test HTML autocorregible</span>
           </span>
+          </a>
+          <a class="tile-src" href="https://github.com/Ismael-Sallami/md2html-testGenerator" target="_blank" rel="noopener"
+             aria-label="Código de md2html en GitHub"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a>
           <span class="tile-arrow" aria-hidden="true">→</span>
-        </a>
-        <a class="tile reveal" style="--i:1" href="https://github.com/Ismael-Sallami/md2html-testGenerator" target="_blank" rel="noopener">
+        </div>
+        <div class="tile tile-dual reveal" style="--i:1">
+          <a class="tile-main" href="/pdf2md/">
           <span class="tile-num">02</span>
-          <span>
-            <span class="tile-title">md2html · código fuente</span>
-
-          </span>
-          <span class="tile-arrow" aria-hidden="true">→</span>
-        </a>
-        <a class="tile reveal" style="--i:2" href="/pdf2md/">
-          <span class="tile-num">03</span>
           <span>
             <span class="tile-title">pdf2md</span>
             <span class="tile-blurb">PDF, Word y Excel a Markdown</span>
           </span>
+          </a>
+          <a class="tile-src" href="https://github.com/Ismael-Sallami/pdf-to-md" target="_blank" rel="noopener"
+             aria-label="Código de pdf2md en GitHub"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a>
           <span class="tile-arrow" aria-hidden="true">→</span>
-        </a>
-        <a class="tile reveal" style="--i:3" href="https://github.com/Ismael-Sallami/pdf-to-md" target="_blank" rel="noopener">
-          <span class="tile-num">04</span>
-          <span>
-            <span class="tile-title">pdf2md · código fuente</span>
-
-          </span>
-          <span class="tile-arrow" aria-hidden="true">→</span>
-        </a>
-        <a class="tile reveal" style="--i:4" href="/diffchecker/">
-          <span class="tile-num">05</span>
+        </div>
+        <div class="tile tile-dual reveal" style="--i:2">
+          <a class="tile-main" href="/diffchecker/">
+          <span class="tile-num">03</span>
           <span>
             <span class="tile-title">diffchecker</span>
             <span class="tile-blurb">comparar dos textos y mezclarlos</span>
           </span>
+          </a>
+          <a class="tile-src" href="https://github.com/Ismael-Sallami/diffchecker" target="_blank" rel="noopener"
+             aria-label="Código de diffchecker en GitHub"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a>
           <span class="tile-arrow" aria-hidden="true">→</span>
-        </a>
+        </div>
       </div>
     </div>
   </main>


### PR DESCRIPTION
Tres cosas, ninguna de contenido: el repositorio que le faltaba a diffchecker, las
tarjetas de Herramientas y el repaso del README.

## `Ismael-Sallami/diffchecker`

Era la única de las tres herramientas sin repositorio propio; md2html y pdf2md sí
lo tienen. Publicado al estándar: **MIT, ocho topics, descripción, CI en verde y
release `v1.0`**, con la estructura de `pdf-to-md`.

Lo que da valor al repositorio es la prueba. Las 417 líneas de
`check-diff-engine.mjs` se copian tal cual y el CI las ejecuta en Node 20 y 22,
porque comprueban la propiedad que de verdad importa:

> Lo que el motor devuelve no es solo lo que se pinta: es lo que el botón de
> descarga escribe.

Por eso `merge()` trabaja sobre las mismas filas que se muestran, y la prueba
comprueba que **quedarse con un lado entero devuelve ese lado byte a byte**. Un
fallo ahí es del peor tipo: la pantalla se ve bien y el fichero descargado no.

Dos detalles para que funcione **desde un clon limpio**, que es lo que exige el
estándar: el `index.html` apuntaba a `/assets/css/tool.css`, una ruta absoluta del
blog, así que la hoja se copia al repositorio y el enlace pasa a ser relativo; y el
CI **falla si vuelve a aparecer una ruta absoluta**, porque eso solo se ve abriendo
la página. Comprobado sirviendo el clon y usando la herramienta.

El blog sigue sirviendo su copia, igual que con md2html y pdf2md, y los dos READMEs
dicen que **si se toca el motor hay que tocar los dos**.

## Las tarjetas de Herramientas

Había **cinco filas para tres herramientas**: una por app y otra por su código.
Ahora son tres, y el repositorio es un **cuadrado lima con la marca de GitHub**
dentro de la tarjeta.

Dos enlaces en una tarjeta no pueden anidarse, así que la que tiene repositorio
pasa a ser un `<div>`: el principal se estira sobre ella con un `::after` y el
cuadrado queda encima con su propio apilamiento. **Las tarjetas sin repositorio no
cambian**, que es lo que usan las secciones de curso.

La marca va en SVG en línea, como los iconos del conmutador de tema: sin CDN ni
fuente de iconos. El cuadrado lleva su propio `aria-label` —un enlace cuyo
contenido es un icono no tiene nombre accesible— y la tarjeta se perfila al recibir
el foco, para que el enlace principal no muestre un contorno de altura cero.

Comprobado en el navegador, en claro y en oscuro: pulsar en cualquier parte de la
tarjeta abre la herramienta, el cuadrado abre el repositorio, hay **dos paradas de
tabulador** y **cero enlaces anidados** en el HTML generado.

## El README

Faltaban cinco cosas, y las cinco son las que se echaron de menos trabajando:

1. **Qué es y qué no.** Con el `CONTRIBUTING.md` retirado a propósito, ningún
   fichero decía que es un archivo personal y que no se buscan colaboradores.
2. **Cómo se añade una guía docente**, que es lo que más veces se ha hecho a mano:
   el patrón de la URL, que **las optativas de Computación y Sistemas Inteligentes
   cuelgan del grado de Informática**, y que cuando esa página da 404 **la guía
   firmada sí existe** con un código que no aparece en ninguna página.
3. **Cómo se enlaza un `.md` para leerlo en el navegador**: `/viewer/?file=<ruta>`.
   Es como se sirven 245 recursos y no estaba escrito en ninguna parte.
4. **Los tests**: el `.md` es la fuente y el `.html` el artefacto; los dos se
   versionan y solo se edita el primero.
5. **La licencia**, que el README no mencionaba nunca: MIT para el código, y los
   apuntes como material propio, con la regla del material ajeno escrita al lado.

Más dos correcciones: `docs/` no estaba en la tabla de carpetas, y ahora se dice
que **tras tocar un `.tex` hay que abrir el PDF y mirarlo**, porque una figura mal
dibujada compila sin una queja.

**Y un badge del workflow de despliegue**, que sale del CI real.

## `CITATION.cff`

Lo que dice la investigación que suele llevar un repositorio así y aquí faltaba.
Con solo tenerlo, GitHub pinta un botón «Cite this repository». `dependabot`,
`CODEOWNERS` y `CHANGELOG` no aplican: cero dependencias, una persona y ninguna
release. El código de conducta sigue fuera a propósito.

## Comprobado

- `npm run check`: **532 enlaces**, 455 locales, todos resuelven. Bajan dos, que son
  las dos filas de código que desaparecen.
- **Cada ruta que nombra el README existe** y cada enlace suyo resuelve, barrido a
  máquina. Es lo que no se hizo durante meses y dejó tres afirmaciones falsas.
- El repositorio nuevo, **desde un clon limpio**: las pruebas pasan y la
  herramienta se abre y compara.
