### PR TITLE
El botón al repositorio, el aviso de seguridad y el README

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,49 +1,41 @@
-# Avisos de seguridad y de material publicado por error
+# Avisos
 
-Este repositorio no es software con usuarios: es un archivo de apuntes. Aun
-así, tres veces ha publicado sin querer algo que no debía, y ese es el aviso
-que sí urge.
+Esto es un archivo de apuntes, no software con usuarios: no hay versiones que
+parchear ni releases que sostener. Se mantiene lo que haya publicado en `main`.
+
+Lo que sí interesa saber es si algo de lo publicado no debería estarlo.
 
 ## Qué avisar
 
-- **Credenciales o claves.** Han aparecido tres claves SSH privadas de un
-  laboratorio y las credenciales de una base de datos de la universidad.
-- **Datos personales.** Un DNI llegó a estar en seis cabeceras de código y en
-  dos PDF, y uno de ellos lo servía la web.
-- **Material con derechos.** Transparencias del profesorado, guiones de
-  prácticas, capítulos de manual. También cuando entra **como imagen** dentro de
-  un documento propio, que es como se colaron seis páginas fotografiadas de un
-  libro.
+- Una clave, un token o una credencial de cualquier tipo.
+- Datos personales, del autor o de cualquiera que salga en el material.
+- Material con derechos: transparencias, guiones de prácticas, capítulos de
+  manual. Cuenta igual cuando va incrustado **como imagen** dentro de un
+  documento propio, que es la forma más fácil de que pase inadvertido.
 
 ## Cómo
 
-**No abras una issue pública** para nada de lo anterior: una issue deja el
-hallazgo indexado mientras se arregla.
+**Para esto no se abre una issue.** Una issue pública deja el hallazgo indexado
+justo mientras se está arreglando, que es lo contrario de lo que hace falta.
 
-- Usa el aviso privado de GitHub, en la pestaña **Security → Report a
-  vulnerability** de este repositorio.
-- Si prefieres el correo, escribe a la dirección pública del perfil
-  [@ElblogdeIsmael](https://github.com/ElblogdeIsmael).
+Hay dos vías privadas:
 
-Dime qué fichero es y, si puedes, en qué línea o página. Con eso basta.
+- La pestaña **Security → Report a vulnerability** de este repositorio.
+- El correo del perfil, [@ElblogdeIsmael](https://github.com/ElblogdeIsmael).
+
+Con el fichero basta. Si además cabe la línea o la página, mejor.
 
 ## Qué pasa después
 
-Un secreto filtrado no se arregla borrando el fichero: sigue en el historial y
-sigue siendo alcanzable. El procedimiento que se ha seguido aquí es rotar la
-credencial primero, reescribir el historial con `git filter-repo` después, y
-mover también las etiquetas, porque mantienen vivo lo purgado.
+Borrar el fichero no resuelve nada: sigue en el historial y sigue siendo
+alcanzable. El procedimiento es rotar primero la credencial, si la hay,
+reescribir el historial con `git filter-repo` después, y **mover también las
+etiquetas**, porque apuntan al historial viejo y lo mantienen vivo.
 
-Las `refs/pull` que GitHub crea por cada pull request son de solo lectura y
-conservan el historial anterior a cualquier reescritura. **Solo el soporte de
-GitHub puede borrarlas**, y en este repositorio lo hizo una vez avisando de que
-no repetiría la excepción. Así que lo purgado antes de agosto de 2026 está
-limpio, y una reescritura futura no lo estaría del todo.
+El material con derechos se retira del árbol y del historial. Se guarda una
+copia local fuera del repositorio, con las rutas originales, para poder
+responder de qué se retiró y de dónde salía.
 
-El material con derechos se retira del árbol y del historial, y se guarda una
-copia local fuera del repositorio con sus rutas originales.
-
-## Versiones
-
-Se mantiene lo que hay publicado en `main`. No hay releases ni versiones
-anteriores que sostener.
+Para erratas, enlaces movidos y cualquier otra cosa que no sea de esta página,
+[las issues](https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io/issues/new/choose)
+tienen dos formularios.

--- a/README.md
+++ b/README.md
@@ -3,21 +3,20 @@
 [![Deploy to GitHub Pages](https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io/actions/workflows/deploy.yml)
 
 Apuntes, prácticas y material del Doble Grado en Ingeniería Informática y ADE
-de la Universidad de Granada. Publicado en
+de la Universidad de Granada. Se publica en
 [elblogdeismael.github.io](https://elblogdeismael.github.io).
 
-**Es un archivo personal, no un proyecto abierto.** No se buscan colaboradores y
-no hay guía de contribución: lo que se publica aquí lo escribe una persona. Si
-encuentras una errata o un enlace movido, hay dos formularios de issue; si lo que
-encuentras es material que no debería estar publicado, mira
-[«Avisos»](#avisos) antes de abrir nada.
+Es un archivo personal, no un proyecto abierto. No se buscan colaboradores ni
+hay guía de contribución: lo que se publica aquí lo escribe una sola persona.
+Para una errata o un enlace movido hay dos formularios de issue. Para material
+que no debería estar publicado, [«Avisos»](#avisos).
 
 ## Cómo funciona
 
 El contenido vive en ficheros de datos. Un generador escrito en Node los lee y
 escribe HTML estático en la raíz del repositorio, que es lo que sirve GitHub
-Pages. No hay dependencias: el sitio publicado son páginas HTML, una hoja de
-estilos y dos scripts de poco más de un kilobyte.
+Pages. Sin dependencias: lo publicado son páginas HTML, una hoja de estilos y
+dos scripts de poco más de un kilobyte.
 
 ```
 content/          datos: qué se publica
@@ -31,9 +30,9 @@ build/            generador: cómo se publica
 assets/css/brutal/  sistema de diseño en cinco capas
 ```
 
-Se genera desde `content/` hacia la raíz: `index.html`, `doble-grado/`,
-`tools/`, `historia/`, `sitemap.xml` y `assets/css/brutal.css`. El HTML
-generado se versiona, así que Pages publica sin necesidad de compilar nada.
+De `content/` sale la raíz entera: `index.html`, `doble-grado/`, `tools/`,
+`historia/`, `sitemap.xml` y `assets/css/brutal.css`. Ese HTML se versiona, así
+que Pages publica sin compilar nada.
 
 ## Comandos
 
@@ -42,111 +41,122 @@ npm run build     # genera el sitio
 npm run dev       # genera y sirve en http://localhost:4173
 npm run check     # falla si el HTML está desactualizado o hay enlaces rotos
 
-# Si has tocado un .tex. Compila fuera del repositorio, así que no pisa nada.
+# Si se ha tocado un .tex. Compila fuera del repositorio, así que no pisa nada.
 node build/scripts/check-latex-builds.mjs --check      # los 100, unos 8 min
 node build/scripts/check-latex-builds.mjs --only FBD   # solo lo tocado
 ```
 
-Necesita Node 20 o superior. No hay que instalar nada.
+Node 20 o superior, y nada que instalar.
 
-**Al tocar un `.tex`, el barrido no basta: hay que abrir el PDF y mirarlo.** Una
+Como el HTML se versiona, tras tocar `content/` toca ejecutar `npm run build`.
+Sin eso el sitio no cambia y el CI falla con `npm run check`.
+
+Ese `check` comprueba que cada enlace local apunta a un fichero que existe, pero
+no pide los externos. Una guía docente que cambie de URL pasa por buena, así que
+esas se barren a mano con `curl`.
+
+Y con los `.tex` el barrido tampoco basta: hay que abrir el PDF y mirarlo. Una
 figura mal dibujada compila sin una sola queja (leyendas encima de las barras,
-rótulos que se salen de su caja, un eje pisado), y eso solo se ve renderizando la
-página con `pdftoppm -f N -l N -r 100 -png`. Lo mismo con las cuentas de un
-ejemplo numérico: un documento compila igual de bien con las sumas mal.
-
-**El HTML generado se versiona.** Después de tocar `content/` hay que ejecutar
-`npm run build` o el sitio no cambia, y el CI falla con `npm run check`.
-
-`npm run check` comprueba que cada enlace local apunta a un fichero que existe.
-**No pide los externos**, así que una guía docente que cambie de URL pasa por
-buena: eso se barre a mano con `curl`.
+rótulos que se salen de su caja, un eje pisado), y eso solo se ve renderizando
+la página con `pdftoppm -f N -l N -r 100 -png`. Con las cuentas de un ejemplo
+numérico pasa igual. Un documento compila perfectamente con las sumas mal.
 
 ## Añadir contenido
 
-**Un recurso a una asignatura.** Abre el curso en
-`content/sections/doble-grado/pages/` y añade una entrada a la lista
-`resources` de esa asignatura. Después `npm run build`.
+### Un recurso, o una asignatura entera
 
-**Una asignatura.** Añade un objeto `{ code, name, blocks }` al semestre que
-toque, en el mismo fichero.
+Los cursos viven en `content/sections/doble-grado/pages/`. Un recurso nuevo es
+una entrada más en la lista `resources` de su asignatura, y una asignatura nueva
+un objeto `{ code, name, blocks }` en el semestre que le toque, en ese mismo
+fichero. Después, `npm run build`.
 
-**La guía docente de una asignatura**, que es el primer recurso de toda ficha:
+### La guía docente
+
+Es el primer recurso de toda ficha. La URL sigue este patrón:
 
 ```
 https://grados.ugr.es/informatica-ade/docencia/plan-estudios/<slug>/guia-docente
 ```
 
-El *slug* sale del índice del plan de estudios. Dos avisos que han costado tiempo
-dos veces:
+El *slug* sale del índice del plan de estudios. Dos avisos, y los dos han
+costado tiempo dos veces:
 
-- **Las optativas de Computación y Sistemas Inteligentes cuelgan del grado de
-  Informática**, no del doble grado: es el caso de MH y de AA, con
+- Las optativas de Computación y Sistemas Inteligentes cuelgan del **grado de
+  Informática**, no del doble grado. Es el caso de MH y de AA, con
   `grados.ugr.es/informatica/…` y otro slug.
-- **Cuando esa página da 404, la guía firmada sí existe** en
-  `guias-firmadas/<curso>/<codigo>.pdf`. El código **no aparece en ninguna
-  página**: se encuentra barriendo el rango y leyendo la primera página del PDF
-  con `pdftotext`. Así salieron FBD (`216113D`) y MAC (`296113D`).
+- Cuando esa página da 404, **la guía firmada sí existe** en
+  `guias-firmadas/<curso>/<codigo>.pdf`. El código no aparece en ninguna página:
+  se encuentra barriendo el rango y leyendo la primera página del PDF con
+  `pdftotext`. Así salieron FBD (`216113D`) y MAC (`296113D`).
 
-Si de verdad no hay guía, el modelo tiene `note: true` para eso. **Nunca
-`href: "#"`.**
+Si de verdad no hay guía, el modelo tiene `note: true` para eso. Nunca
+`href: "#"`.
 
-**Un apunte que se lea en el navegador.** Enlázalo con `/viewer/?file=<ruta>`,
-nunca con una ruta relativa al `.md`. Así se sirven 245 recursos: el visor
-descarga el markdown y lo renderiza en la página, con las figuras de tikz
-compiladas al vuelo.
+### Un apunte que se lea en el navegador
 
-**Un test autocorregible.** El `test/*.md` es la fuente y el `test/*.html` el
-artefacto que genera md2html. Los dos se versionan, porque Pages sirve el HTML
-directamente, pero **solo se edita el `.md`**.
+Se enlaza con `/viewer/?file=<ruta>`, nunca con una ruta relativa al `.md`. Así
+se sirven 245 recursos: el visor descarga el markdown y lo renderiza en la
+página, con las figuras de tikz compiladas al vuelo.
 
-**Los apuntes de una asignatura**, que es escribir un PDF nuevo:
+### Un test autocorregible
+
+El `test/*.md` es la fuente y el `test/*.html` el artefacto que genera md2html.
+Los dos se versionan, porque Pages sirve el HTML directamente, pero solo se
+edita el `.md`.
+
+### Los apuntes de una asignatura
+
+Que es escribir un PDF nuevo:
 
 1. `cp -r Subjects/_template Subjects/Second/SO`
 2. En el `Makefile`, `PROJECT = SO`.
-3. Escribe en `src/`, un fichero por tema. Se escribe **en Markdown**; el LaTeX
-   solo para lo que Markdown no cubre, y dentro del propio `.md`.
-4. `make` deja el PDF en `build/SO.pdf`. Enlázalo y `npm run build`.
+3. Un fichero por tema en `src/`, **en Markdown**. El LaTeX, solo para lo que
+   Markdown no cubre, y dentro del propio `.md`.
+4. `make` deja el PDF en `build/SO.pdf`. Se enlaza y `npm run build`.
 
 Está todo en [`Subjects/_template/README.md`](Subjects/_template/README.md).
 
-**Un curso**, o cualquier otra página dentro de una sección:
+### Un curso, o cualquier página dentro de una sección
 
 1. Un fichero en `content/sections/<seccion>/pages/<slug>.mjs`, con `slug`,
    `index`, `title`, `titleOutline`, `meta` y `groups`.
-2. Impórtalo en el `section.mjs` de esa sección y añádelo al array `pages`.
+2. Importarlo en el `section.mjs` de esa sección y añadirlo al array `pages`.
 3. `npm run build`
 
 El orden del array es el orden que se ve, y de ahí salen solos el índice de la
 sección, las migas de pan, los enlaces de anterior y siguiente, y el sitemap.
 
-**Una sección nueva** (investigación, proyectos, lo que sea):
+### Una sección nueva
+
+Investigación, proyectos, lo que sea:
 
 1. `cp -r content/sections/_template content/sections/investigacion`
-2. Rellena `section.mjs` y las páginas de `pages/`.
-3. Impórtala en `content/registry.mjs` y añádela al array `SECTIONS`.
+2. Rellenar `section.mjs` y las páginas de `pages/`.
+3. Importarla en `content/registry.mjs` y añadirla al array `SECTIONS`.
 4. `npm run build`
 
 Aparece sola en la portada, con su índice en `/investigacion/`, una página por
-entrada y sus filas en el sitemap. No hay que tocar plantillas ni CSS.
+entrada y sus filas en el sitemap. Sin tocar plantillas ni CSS.
 
-**Una herramienta.** Las apps del navegador son el caso de sección **sin
-páginas**: `content/sections/tools/section.mjs` tiene `pages: []` y un array
-`links`, y el generador pinta una lista de enlaces en vez de una rejilla
-siempre que `links` esté puesto. Así que:
+### Una herramienta
+
+Las apps del navegador son el caso de sección **sin páginas**:
+`content/sections/tools/section.mjs` tiene `pages: []` y un array `links`, y el
+generador pinta una lista de enlaces en vez de una rejilla siempre que `links`
+esté puesto. Así que:
 
 1. La app, entera, en su carpeta de la raíz (`diffchecker/`, `md2html/`…).
-2. Una entrada en `links` con `name`, `href` y `kind`. Si el código vive en un
-   repositorio aparte, una segunda entrada apuntando a él, como hacen md2html y
-   pdf2md.
+2. Una entrada en `links` con `name`, `href` y `kind`. El `blurb` es la línea de
+   debajo del nombre, y el `repo` pinta el cuadrado que lleva al código.
 3. `npm run build`
 
-**El JS de `md2html/`, `pdf2md/` y `viewer/` no se toca**: su CSS depende de los
+El JS de `md2html/`, `pdf2md/` y `viewer/` no se toca. Su CSS depende de los
 nombres de clase que ese JS manipula (`light`, `dragover`, `active`), así que
 renombrar uno rompe el estilo sin que nada falle.
 
-El modelo es el mismo para todo. Un curso y un área de investigación se
-describen igual:
+### El modelo
+
+Es el mismo para todo. Un curso y un área de investigación se describen igual:
 
 | Nivel      | Doble Grado    | Investigación     |
 | ---------- | -------------- | ----------------- |
@@ -156,23 +166,23 @@ describen igual:
 | `Entry`    | Asignatura     | Proyecto          |
 | `Resource` | Apuntes en PDF | Publicación       |
 
-Los campos están documentados en `content/types.d.ts`, que da autocompletado
-en el editor sin necesidad de compilar TypeScript.
+Los campos están documentados en `content/types.d.ts`, que da autocompletado en
+el editor sin necesidad de compilar TypeScript.
 
 ## Diseño
 
 Brutalismo: bordes duros de 2 px, sombras desplazadas sin difuminar, rejilla
-técnica de fondo, tipografía grande con la segunda mitad en contorno.
-Tipos: Bricolage Grotesque para display, Manrope para texto.
+técnica de fondo, tipografía grande con la segunda mitad en contorno. Los tipos
+son Bricolage Grotesque para display y Manrope para texto.
 
-**El tema claro es el de por defecto**: papel `#eef2ef` con sombras duras
-oscuras y acentos teal `#0f9e86` y lima `#4fb31f`. El oscuro (carbón `#0d0f12`
-con teal `#2ee6c5` y lima `#b8ff3c`) se elige en el conmutador y se recuerda.
-No se consulta la preferencia del sistema: la web está diseñada en claro.
+El tema claro es el de por defecto: papel `#eef2ef` con sombras duras oscuras y
+acentos teal `#0f9e86` y lima `#4fb31f`. El oscuro (carbón `#0d0f12` con teal
+`#2ee6c5` y lima `#b8ff3c`) se elige en el conmutador y se recuerda. No se
+consulta la preferencia del sistema, porque la web está diseñada en claro.
 
-Las cinco capas de `assets/css/brutal/` se editan por separado y el build las
-concatena en `assets/css/brutal.css`. Ese fichero está generado: no se edita a
-mano.
+El build concatena las cinco capas de `assets/css/brutal/` en un solo
+`assets/css/brutal.css`. Ese fichero está generado: se editan las capas, nunca
+él.
 
 ## Qué es cada carpeta
 
@@ -198,39 +208,41 @@ Las que **genera el build** y no se editan a mano:
 | `courses/` | Las URLs antiguas, que redirigen a su sitio nuevo |
 
 `doble-grado` es el *slug* de la sección, así que da nombre a la URL y a la
-carpeta generada. Una sección nueva (investigación, proyectos, lo que sea)
-aparece igual con solo registrarla: ver «Añadir contenido».
+carpeta generada. Una sección nueva aparece igual con solo registrarla, como
+cuenta «Añadir contenido».
 
-**`extraFiles/` y `htmlFiles/` no se borran**, aunque el generador no los
-enlace. `extraFiles/preambulos_oficiales/` es la plantilla LaTeX compartida:
-una veintena de documentos de tercero y cuarto hacen `\input` de `estilo.latex`,
-`paquetes.tex`, `comandos.tex`, `estilos.tex`, `licencia.tex`,
-`referencias.tex` y `metadata.yaml`, y las portadas leen las imágenes de
-`extraFiles/img/`. Y `htmlFiles/history.html` es un stub de redirección vivo a
-`/historia.html`, igual que los de `courses/`.
+Ni `extraFiles/` ni `htmlFiles/` se borran, aunque el generador no las enlace.
+`extraFiles/preambulos_oficiales/` es la plantilla LaTeX compartida: una
+veintena de documentos de tercero y cuarto hacen `\input` de `estilo.latex`,
+`paquetes.tex`, `comandos.tex`, `estilos.tex`, `licencia.tex`, `referencias.tex`
+y `metadata.yaml`, y las portadas leen las imágenes de `extraFiles/img/`. Y
+`htmlFiles/history.html` es un stub de redirección vivo a `/historia.html`,
+igual que los de `courses/`.
 
-Al buscar quién usa un fichero hay que grepear **también los Makefile**, no
-solo el HTML y el JS: la nota que este README tuvo durante meses daba las dos
-carpetas por muertas porque solo miró los `.html`, `.css`, `.mjs` y `.js`.
+De ahí sale una regla: al buscar quién usa un fichero hay que grepear también
+los Makefile, no solo el HTML y el JS. La nota que este README tuvo durante
+meses daba las dos carpetas por muertas porque solo miró los `.html`, `.css`,
+`.mjs` y `.js`.
 
 ## Avisos
 
-Si encuentras una clave, un dato personal o material con derechos de autor
-publicado aquí, **no se avisa en una issue pública**: cómo hacerlo está en
-[`.github/SECURITY.md`](.github/SECURITY.md). Para una errata o un enlace
-movido hay dos formularios de issue.
+Si aparece publicada aquí una clave, un dato personal o material con derechos de
+autor, no se avisa en una issue pública: cómo hacerlo está en
+[`.github/SECURITY.md`](.github/SECURITY.md). Para una errata o un enlace movido
+hay dos formularios de issue.
 
 ## Licencia
 
-El **código** (el generador, las plantillas, el sistema de diseño y las tres apps
-del navegador) va bajo MIT, en [`LICENSE`](LICENSE).
+El **código** (el generador, las plantillas, el sistema de diseño y las tres
+apps del navegador) va bajo MIT, en [`LICENSE`](LICENSE).
 
 Los **apuntes** son material propio, escritos siguiendo la guía docente de cada
-asignatura y con su bibliografía citada donde el texto se apoya en ella. Si los
-reutilizas, cita de dónde salen. Y lo que no está aquí y no va a estar: material
-del profesorado, guiones, transparencias y capítulos de manual, **tampoco
-incrustados como imagen dentro de un documento propio**, que es por donde se
-coló tres veces.
+asignatura y con su bibliografía citada donde el texto se apoya en ella. Quien
+los reutilice, que cite de dónde salen.
+
+Y lo que no está aquí y no va a estar: material del profesorado, guiones,
+transparencias y capítulos de manual, tampoco incrustados como imagen dentro de
+un documento propio.
 
 ## Contacto
 

--- a/assets/css/brutal.css
+++ b/assets/css/brutal.css
@@ -297,9 +297,125 @@ a {
   color: var(--accent);
 }
 
+/* The brand and the repository button are one group, so they share a flex box.
+   The bar is justify-content: space-between and counts on two children; a third
+   one would drift to the middle. */
+.topbar-left {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+}
+
 .topbar-right {
   display: flex;
   align-items: stretch;
+}
+
+/* ---- Repository button --------------------------------------------------
+   Opens the source of the site. Three things move and none of them changes
+   the size of the cell: a lime block sweeps across it twice on load, the mark
+   turns once on hover, and the word flips for the one stacked under it.
+
+   Nothing is lifted with a translate here, unlike the tiles. The bar is
+   sticky, so moving a cell would pull its border out of line with the ones
+   next to it. The motion is fill and flip instead. */
+.topbar-repo {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--ink);
+  padding: 0 20px;
+  border-right: var(--line) solid var(--ink);
+  white-space: nowrap;
+  transition:
+    background var(--base) ease,
+    color var(--base) ease;
+}
+
+/* The sweep. Two passes and it is done: this bar is on every page, so a loop
+   would be noise rather than a cue. It ends off screen because the animation
+   has no fill mode, which leaves the cell exactly as it started.
+
+   Linear, like the marquee, and for the same reason. Something crossing a
+   distance moves at a constant speed; `--ease` is for a control settling into
+   place, and it would send the block 93% of the way in the first half of the
+   run and then crawl. */
+.topbar-repo::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--accent-2);
+  transform: translateX(-100%);
+  animation: repo-sweep 0.75s linear 0.35s 2;
+}
+
+@keyframes repo-sweep {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+/* Above the sweep, so the label stays readable while it passes. */
+.repo-mark,
+.repo-words {
+  position: relative;
+  z-index: 1;
+}
+
+.repo-mark {
+  display: grid;
+  place-items: center;
+  transition: transform var(--slow) var(--ease);
+}
+
+/* One cell, two words, and the cell clips. That is what keeps the width fixed
+   through the flip. */
+.repo-words {
+  display: grid;
+  overflow: hidden;
+}
+
+.repo-word {
+  grid-area: 1 / 1;
+  transition: transform var(--base) var(--ease);
+}
+
+.repo-word-alt {
+  transform: translateY(110%);
+}
+
+.topbar-repo:hover,
+.topbar-repo:focus-visible {
+  background: var(--accent-2);
+  color: var(--accent-ink);
+}
+.topbar-repo:hover .repo-mark,
+.topbar-repo:focus-visible .repo-mark {
+  transform: rotate(360deg);
+}
+.topbar-repo:hover .repo-word,
+.topbar-repo:focus-visible .repo-word {
+  transform: translateY(-110%);
+}
+.topbar-repo:hover .repo-word-alt,
+.topbar-repo:focus-visible .repo-word-alt {
+  transform: translateY(0);
+}
+
+/* Motion off: the sweep never runs and the flip is not needed, so the second
+   word stays out of the way and only the fill answers the pointer. */
+@media (prefers-reduced-motion: reduce) {
+  .topbar-repo::before {
+    content: none;
+  }
 }
 
 .topbar-link {
@@ -527,6 +643,10 @@ a {
   .topbar-toggle {
     padding: 0 16px;
   }
+  .topbar-repo {
+    padding: 0 14px;
+    font-size: 0.7rem;
+  }
   .ttl-stroke {
     -webkit-text-stroke-width: 1.5px;
   }
@@ -536,6 +656,14 @@ a {
   /* Drop secondary nav links; the brand and the theme switch stay. */
   .topbar-link[data-optional] {
     display: none;
+  }
+  /* The repository button loses its label and keeps the mark, which is still
+     a target and still says where it goes through its aria-label. */
+  .topbar-repo .repo-words {
+    display: none;
+  }
+  .topbar-repo {
+    padding: 0 16px;
   }
 }
 

--- a/assets/css/brutal/layout.css
+++ b/assets/css/brutal/layout.css
@@ -59,9 +59,125 @@
   color: var(--accent);
 }
 
+/* The brand and the repository button are one group, so they share a flex box.
+   The bar is justify-content: space-between and counts on two children; a third
+   one would drift to the middle. */
+.topbar-left {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+}
+
 .topbar-right {
   display: flex;
   align-items: stretch;
+}
+
+/* ---- Repository button --------------------------------------------------
+   Opens the source of the site. Three things move and none of them changes
+   the size of the cell: a lime block sweeps across it twice on load, the mark
+   turns once on hover, and the word flips for the one stacked under it.
+
+   Nothing is lifted with a translate here, unlike the tiles. The bar is
+   sticky, so moving a cell would pull its border out of line with the ones
+   next to it. The motion is fill and flip instead. */
+.topbar-repo {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--ink);
+  padding: 0 20px;
+  border-right: var(--line) solid var(--ink);
+  white-space: nowrap;
+  transition:
+    background var(--base) ease,
+    color var(--base) ease;
+}
+
+/* The sweep. Two passes and it is done: this bar is on every page, so a loop
+   would be noise rather than a cue. It ends off screen because the animation
+   has no fill mode, which leaves the cell exactly as it started.
+
+   Linear, like the marquee, and for the same reason. Something crossing a
+   distance moves at a constant speed; `--ease` is for a control settling into
+   place, and it would send the block 93% of the way in the first half of the
+   run and then crawl. */
+.topbar-repo::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--accent-2);
+  transform: translateX(-100%);
+  animation: repo-sweep 0.75s linear 0.35s 2;
+}
+
+@keyframes repo-sweep {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+/* Above the sweep, so the label stays readable while it passes. */
+.repo-mark,
+.repo-words {
+  position: relative;
+  z-index: 1;
+}
+
+.repo-mark {
+  display: grid;
+  place-items: center;
+  transition: transform var(--slow) var(--ease);
+}
+
+/* One cell, two words, and the cell clips. That is what keeps the width fixed
+   through the flip. */
+.repo-words {
+  display: grid;
+  overflow: hidden;
+}
+
+.repo-word {
+  grid-area: 1 / 1;
+  transition: transform var(--base) var(--ease);
+}
+
+.repo-word-alt {
+  transform: translateY(110%);
+}
+
+.topbar-repo:hover,
+.topbar-repo:focus-visible {
+  background: var(--accent-2);
+  color: var(--accent-ink);
+}
+.topbar-repo:hover .repo-mark,
+.topbar-repo:focus-visible .repo-mark {
+  transform: rotate(360deg);
+}
+.topbar-repo:hover .repo-word,
+.topbar-repo:focus-visible .repo-word {
+  transform: translateY(-110%);
+}
+.topbar-repo:hover .repo-word-alt,
+.topbar-repo:focus-visible .repo-word-alt {
+  transform: translateY(0);
+}
+
+/* Motion off: the sweep never runs and the flip is not needed, so the second
+   word stays out of the way and only the fill answers the pointer. */
+@media (prefers-reduced-motion: reduce) {
+  .topbar-repo::before {
+    content: none;
+  }
 }
 
 .topbar-link {
@@ -289,6 +405,10 @@
   .topbar-toggle {
     padding: 0 16px;
   }
+  .topbar-repo {
+    padding: 0 14px;
+    font-size: 0.7rem;
+  }
   .ttl-stroke {
     -webkit-text-stroke-width: 1.5px;
   }
@@ -298,6 +418,14 @@
   /* Drop secondary nav links; the brand and the theme switch stay. */
   .topbar-link[data-optional] {
     display: none;
+  }
+  /* The repository button loses its label and keeps the mark, which is still
+     a target and still says where it goes through its aria-label. */
+  .topbar-repo .repo-words {
+    display: none;
+  }
+  .topbar-repo {
+    padding: 0 16px;
   }
 }
 

--- a/build/lib/icons.mjs
+++ b/build/lib/icons.mjs
@@ -1,0 +1,20 @@
+/**
+ * Inline SVG icons shared by more than one template.
+ *
+ * They live here rather than in a template because two templates draw the
+ * GitHub mark: the tools index paints it inside a tile, and the top bar paints
+ * it in the button that opens this repository.
+ *
+ * All of them are inlined instead of loaded from an icon font or a CDN, which
+ * is the same reason the site ships no dependencies at all.
+ *
+ * @author Ismael Sallami Moreno
+ */
+
+/**
+ * GitHub's octocat, from their official mark. Filled with `currentColor` so it
+ * inverts along with whatever cell holds it.
+ */
+export const GITHUB_MARK = `<svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>`;
+
+export default { GITHUB_MARK };

--- a/build/templates/layout.mjs
+++ b/build/templates/layout.mjs
@@ -6,6 +6,7 @@
  */
 
 import { escape, each, join, isExternal } from "../lib/html.mjs";
+import { GITHUB_MARK } from "../lib/icons.mjs";
 import site from "../../content/site.mjs";
 
 /**
@@ -52,6 +53,34 @@ const ICON_SUN = `<svg class="ico-sun" ${ICON_ATTRS}>
       <circle cx="12" cy="12" r="4"/>
       <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
     </svg>`;
+
+/**
+ * Button that opens the repository this site is built from. It sits next to the
+ * brand because that is what it belongs to: the site and its source.
+ *
+ * The two words are stacked in one grid cell and the cell clips them, so the
+ * hover flip swaps them without the button ever changing width. Same trick as
+ * the theme switch, and for the same reason: the top bar is sticky and anything
+ * that resizes there drags the whole row with it.
+ *
+ * The words carry `aria-hidden` because the link already states its purpose in
+ * `aria-label`; without it a screen reader would read both halves of the flip.
+ *
+ * @returns {string} the button, or nothing when no repository is configured
+ */
+function repoButton() {
+  if (!site.repo) return "";
+
+  return `    <a class="topbar-repo" href="${escape(site.repo)}"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true">${GITHUB_MARK}</span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>`;
+}
 
 /**
  * @typedef {object} NavLink
@@ -194,7 +223,10 @@ ${thirdParty(options)}
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/">${BRAND_MARK}<span class="brand-long">${escape(site.name)}</span></a>
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/">${BRAND_MARK}<span class="brand-long">${escape(site.name)}</span></a>
+${repoButton()}
+    </div>
     <div class="topbar-right">
 ${navLinks(options.nav ?? [])}
       <button class="topbar-toggle" type="button" data-theme-toggle

--- a/build/templates/section.mjs
+++ b/build/templates/section.mjs
@@ -9,6 +9,7 @@
 
 import { escape, each, isExternal, url, heading } from "../lib/html.mjs";
 import { layout } from "./layout.mjs";
+import { GITHUB_MARK } from "../lib/icons.mjs";
 
 /**
  * @param {import("../../content/types.d.ts").Section} section
@@ -42,12 +43,6 @@ function pageTile(section, page, index) {
           <span class="tile-arrow" aria-hidden="true">→</span>
         </a>`;
 }
-
-/*
- * La marca de GitHub, en linea. Es el mismo criterio que los iconos del
- * conmutador de tema: SVG propio en el HTML, sin CDN ni fuente de iconos.
- */
-const GITHUB_MARK = `<svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>`;
 
 /**
  * @param {import("../../content/types.d.ts").Resource} link

--- a/content/site.mjs
+++ b/content/site.mjs
@@ -37,6 +37,13 @@ export const site = {
   /** Where the contact form posts. */
   contactEndpoint: "https://formsubmit.co/ismEngineer23@gmail.com",
 
+  /**
+   * The repository this site is generated from. It is not the same as the
+   * GitHub account below: that one is the person, this one is the code.
+   * The top bar links to it, next to the brand.
+   */
+  repo: "https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io",
+
   social: [
     { label: "GitHub", href: "https://github.com/ismael-sallami" },
     { label: "Web personal", href: "https://ismael-sallami.github.io/" },

--- a/doble-grado/cuarto/index.html
+++ b/doble-grado/cuarto/index.html
@@ -46,13 +46,24 @@
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
       fill="none" stroke="currentColor" stroke-width="2"
       stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
       <path d="M12 3 23 8l-11 5L1 8z"/>
       <path d="M5 10.5V15c0 1.7 3.1 3 7 3s7-1.3 7-3v-4.5"/>
       <path d="M23 8v6"/>
     </svg><span class="brand-long">Recursos GIIADE</span></a>
+    <a class="topbar-repo" href="https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>
+    </div>
     <div class="topbar-right">
         <a class="topbar-link" href="/doble-grado/">← Doble Grado</a>
       <button class="topbar-toggle" type="button" data-theme-toggle

--- a/doble-grado/index.html
+++ b/doble-grado/index.html
@@ -46,13 +46,24 @@
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
       fill="none" stroke="currentColor" stroke-width="2"
       stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
       <path d="M12 3 23 8l-11 5L1 8z"/>
       <path d="M5 10.5V15c0 1.7 3.1 3 7 3s7-1.3 7-3v-4.5"/>
       <path d="M23 8v6"/>
     </svg><span class="brand-long">Recursos GIIADE</span></a>
+    <a class="topbar-repo" href="https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>
+    </div>
     <div class="topbar-right">
         <a class="topbar-link" href="/">← Inicio</a>
       <button class="topbar-toggle" type="button" data-theme-toggle

--- a/doble-grado/primero/index.html
+++ b/doble-grado/primero/index.html
@@ -46,13 +46,24 @@
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
       fill="none" stroke="currentColor" stroke-width="2"
       stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
       <path d="M12 3 23 8l-11 5L1 8z"/>
       <path d="M5 10.5V15c0 1.7 3.1 3 7 3s7-1.3 7-3v-4.5"/>
       <path d="M23 8v6"/>
     </svg><span class="brand-long">Recursos GIIADE</span></a>
+    <a class="topbar-repo" href="https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>
+    </div>
     <div class="topbar-right">
         <a class="topbar-link" href="/doble-grado/">← Doble Grado</a>
       <button class="topbar-toggle" type="button" data-theme-toggle

--- a/doble-grado/quinto/index.html
+++ b/doble-grado/quinto/index.html
@@ -46,13 +46,24 @@
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
       fill="none" stroke="currentColor" stroke-width="2"
       stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
       <path d="M12 3 23 8l-11 5L1 8z"/>
       <path d="M5 10.5V15c0 1.7 3.1 3 7 3s7-1.3 7-3v-4.5"/>
       <path d="M23 8v6"/>
     </svg><span class="brand-long">Recursos GIIADE</span></a>
+    <a class="topbar-repo" href="https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>
+    </div>
     <div class="topbar-right">
         <a class="topbar-link" href="/doble-grado/">← Doble Grado</a>
       <button class="topbar-toggle" type="button" data-theme-toggle

--- a/doble-grado/segundo/index.html
+++ b/doble-grado/segundo/index.html
@@ -46,13 +46,24 @@
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
       fill="none" stroke="currentColor" stroke-width="2"
       stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
       <path d="M12 3 23 8l-11 5L1 8z"/>
       <path d="M5 10.5V15c0 1.7 3.1 3 7 3s7-1.3 7-3v-4.5"/>
       <path d="M23 8v6"/>
     </svg><span class="brand-long">Recursos GIIADE</span></a>
+    <a class="topbar-repo" href="https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>
+    </div>
     <div class="topbar-right">
         <a class="topbar-link" href="/doble-grado/">← Doble Grado</a>
       <button class="topbar-toggle" type="button" data-theme-toggle

--- a/doble-grado/tercero/index.html
+++ b/doble-grado/tercero/index.html
@@ -46,13 +46,24 @@
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
       fill="none" stroke="currentColor" stroke-width="2"
       stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
       <path d="M12 3 23 8l-11 5L1 8z"/>
       <path d="M5 10.5V15c0 1.7 3.1 3 7 3s7-1.3 7-3v-4.5"/>
       <path d="M23 8v6"/>
     </svg><span class="brand-long">Recursos GIIADE</span></a>
+    <a class="topbar-repo" href="https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>
+    </div>
     <div class="topbar-right">
         <a class="topbar-link" href="/doble-grado/">← Doble Grado</a>
       <button class="topbar-toggle" type="button" data-theme-toggle

--- a/historia/index.html
+++ b/historia/index.html
@@ -46,13 +46,24 @@
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
       fill="none" stroke="currentColor" stroke-width="2"
       stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
       <path d="M12 3 23 8l-11 5L1 8z"/>
       <path d="M5 10.5V15c0 1.7 3.1 3 7 3s7-1.3 7-3v-4.5"/>
       <path d="M23 8v6"/>
     </svg><span class="brand-long">Recursos GIIADE</span></a>
+    <a class="topbar-repo" href="https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>
+    </div>
     <div class="topbar-right">
         <a class="topbar-link" href="/">← Inicio</a>
       <button class="topbar-toggle" type="button" data-theme-toggle

--- a/index.html
+++ b/index.html
@@ -48,13 +48,24 @@
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
       fill="none" stroke="currentColor" stroke-width="2"
       stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
       <path d="M12 3 23 8l-11 5L1 8z"/>
       <path d="M5 10.5V15c0 1.7 3.1 3 7 3s7-1.3 7-3v-4.5"/>
       <path d="M23 8v6"/>
     </svg><span class="brand-long">Recursos GIIADE</span></a>
+    <a class="topbar-repo" href="https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>
+    </div>
     <div class="topbar-right">
         <a class="topbar-link" href="/doble-grado/" data-optional>Doble Grado</a>
         <a class="topbar-link" href="/tools/" data-optional>Herramientas</a>

--- a/tools/index.html
+++ b/tools/index.html
@@ -46,13 +46,24 @@
   <a class="skip-link" href="#main">Saltar al contenido</a>
 
   <header class="topbar">
-    <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
+    <div class="topbar-left">
+      <a class="topbar-brand" href="/"><svg class="brand-mark" viewBox="0 0 24 24" width="20" height="20"
       fill="none" stroke="currentColor" stroke-width="2"
       stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
       <path d="M12 3 23 8l-11 5L1 8z"/>
       <path d="M5 10.5V15c0 1.7 3.1 3 7 3s7-1.3 7-3v-4.5"/>
       <path d="M23 8v6"/>
     </svg><span class="brand-long">Recursos GIIADE</span></a>
+    <a class="topbar-repo" href="https://github.com/ElblogdeIsmael/ElblogdeIsmael.github.io"
+       target="_blank" rel="noopener"
+       aria-label="Ver el código de este sitio en GitHub">
+      <span class="repo-mark" aria-hidden="true"><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></span>
+      <span class="repo-words" aria-hidden="true">
+        <span class="repo-word">Código</span>
+        <span class="repo-word repo-word-alt">GitHub</span>
+      </span>
+    </a>
+    </div>
     <div class="topbar-right">
         <a class="topbar-link" href="/">← Inicio</a>
       <button class="topbar-toggle" type="button" data-theme-toggle


### PR DESCRIPTION
Los tres commits que se empujaron a esta rama después de que se fusionara la #43.
GitHub no los añade a una PR ya cerrada, así que se quedaron sin llegar a `main` y
la web publicada no los tiene: el último despliegue de Pages es el `ef1dbdf` del
merge de la #43.

## Qué entra

**El botón al repositorio.** El sitio se genera desde aquí y ninguna página
enlazaba al código: el pie ofrece la cuenta de GitHub, que es la persona. Ahora
hay una celda en la barra superior, a la derecha de la marca y compartiendo su
regla. Al cargar, un bloque lima barre la celda dos veces y para; en hover y con
el foco de teclado, relleno lima, la marca gira 360° y la palabra se voltea de
«Código» a «GitHub». Las dos palabras comparten una celda que las recorta, así el
botón no cambia de ancho al alternar, y no se levanta nada con `translate`: la
barra es pegajosa y mover una celda le desalinea el borde con las de al lado.

`GITHUB_MARK` pasa de `section.mjs` a `build/lib/icons.mjs`, porque ahora lo
dibujan dos plantillas. La URL vive en `content/site.mjs`, campo `repo`, que no es
lo mismo que el GitHub de `social`.

**`SECURITY.md` sin el parte de incidencias.** Abría contando que el repositorio
había publicado sin querer algo que no debía tres veces, y detallaba qué. Eso no
hace falta para ofrecer un canal privado y deja los incidentes indexados en la
pestaña de seguridad de un repositorio público. Se queda lo que le sirve a quien
avisa: qué avisar, cómo sin abrir una issue, y qué pasa después.

**El README, con un ritmo en vez de dieciséis aperturas iguales.** El impersonal
se queda, que es el registro de la documentación técnica en español. Lo delator
era la uniformidad, y el patrón lo introdujo el arreglo del día anterior: al
quitar los guiones largos, `**Término** — texto` se convirtió en `**Término.**
Texto` dieciséis veces seguidas.

| Marca | Antes | Ahora |
| --- | ---: | ---: |
| Párrafos que abren con rótulo en negrita | 16 | 0 |
| Formas en segunda persona | 11 | 0 |
| Longitud de párrafo | casi todos de 60 a 75 palabras | de 2 a 73 |

Comprobado a máquina que no se perdió nada: cada fragmento en código, cada URL y
cada cifra del README viejo sigue en el nuevo.

## Comprobado

- `npm run check`: 533 enlaces, 456 locales, todos resuelven.
- El botón sale en las 9 páginas con barra superior, y abierto en el navegador se
  ve donde toca, con su barrido, su giro y su volteo.
- `npm run check` no cuenta este enlace, y está bien: mira los de `content/`, no
  los del HTML, así que la barra superior nunca ha entrado en los 533.
